### PR TITLE
[volume-1] 회원가입 API 및 테스트

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -1,0 +1,16 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserFacade {
+	private final UserService userService;
+
+	public UserInfo createUser(UserV1Dto.SignUpRequest signUpRequest) {
+		return userService.createUser(signUpRequest);
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
@@ -1,0 +1,17 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.constant.Gender;
+
+public record UserInfo(Long id, String userId, String name, Gender gender, String birth, String email) {
+	public static UserInfo from(UserEntity user){
+		return new UserInfo(
+				user.getId(),
+				user.getUserId(),
+				user.getName(),
+				user.getGender(),
+				user.getBirth(),
+				user.getEmail()
+		);
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -1,0 +1,57 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.user.constant.Gender;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor
+public class UserEntity extends BaseEntity {
+
+	@Column(name = "user_id", nullable = false, unique = true)
+	private String userId;
+	@Column(nullable = false)
+	private String name;
+	@Enumerated(EnumType.STRING)
+	private Gender gender;
+	@Column(nullable = false)
+	private String birth;
+	@Column(nullable = false)
+	private String email;
+
+	public static final String PATTERN_USER_ID = "^[a-zA-Z0-9]{1,10}$";
+	public static final String PATTERN_EMAIL = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
+	public static final String PATTERN_BIRTH = "^\\d{4}-\\d{2}-\\d{2}$";
+
+	UserEntity(
+			String userId,
+			String name,
+			Gender gender,
+			String email,
+			String birth
+	){
+		if (userId == null || !userId.matches(PATTERN_USER_ID)) {
+			throw new CoreException(ErrorType.BAD_REQUEST, "ID는 영문 및 숫자 10자 이내여야 합니다.");
+		}
+
+		if (!email.matches(PATTERN_EMAIL)) {
+			throw new CoreException(ErrorType.BAD_REQUEST, "이메일은 xx@yy.zz 형식이여야 합니다.");
+		}
+
+		if (!birth.matches(PATTERN_BIRTH)) {
+			throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 yyyy-MM-dd 형식에 맞아야 합니다.");
+		}
+
+		this.userId = userId;
+		this.name = name;
+		this.gender = gender;
+		this.email = email;
+		this.birth = birth;
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.user;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+	Optional<UserEntity> createUser(UserEntity userEntity);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.user;
+
+import com.loopers.application.user.UserInfo;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class UserService {
+	private final UserRepository userRepository;
+
+	@Transactional
+	public UserInfo createUser(UserV1Dto.SignUpRequest signUpRequest){
+		UserEntity userEntity = new UserEntity(signUpRequest.userId(),
+				signUpRequest.name(),
+				signUpRequest.gender(),
+				signUpRequest.email(),
+				signUpRequest.birth());
+
+		UserEntity user
+				= userRepository.createUser(userEntity).orElseThrow(()->{
+			return new CoreException(ErrorType.BAD_REQUEST, "회원 가입에 실패하였습니다.");
+		});
+
+		return UserInfo.from(user);
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/constant/Gender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/constant/Gender.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.user.constant;
+
+public enum Gender {
+	M, F
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UserRepositoryImpl implements UserRepository {
+	private final UserJpaRepository userJpaRepository;
+
+	@Override
+	public Optional<UserEntity> createUser(UserEntity userEntity) {
+		try {
+			UserEntity user = userJpaRepository.save(userEntity);
+			return Optional.of(user);
+		} catch (Exception e) {
+			return Optional.empty();
+		}
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -8,6 +8,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -30,6 +31,16 @@ public class ApiControllerAdvice {
     }
 
     @ExceptionHandler
+	public ResponseEntity<ApiResponse<?>> handle(MethodArgumentNotValidException e) {
+		String message = e.getBindingResult().getFieldErrors().stream()
+				.findFirst()
+				.map(error -> error.getDefaultMessage())
+				.orElse("잘못된 요청입니다.");
+
+		return failureResponse(ErrorType.BAD_REQUEST, message);
+	}
+
+	@ExceptionHandler
     public ResponseEntity<ApiResponse<?>> handleBadRequest(MethodArgumentTypeMismatchException e) {
         String name = e.getName();
         String type = e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown";

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserFacade;
+import com.loopers.application.user.UserInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserV1ApiController implements UserV1ApiSpec {
+
+	private final UserFacade userFacade;
+
+	@PostMapping
+	@Override
+	public ApiResponse<UserV1Dto.UserResponse> signUp(
+			@RequestBody @Valid UserV1Dto.SignUpRequest signUpRequest) {
+
+		UserInfo user = userFacade.createUser(signUpRequest);
+		UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(user);
+		return ApiResponse.success(response);
+
+	}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User V1 API", description = "사용자 API 입니다.")
+public interface UserV1ApiSpec {
+
+	@Operation(summary = "회원 가입")
+	ApiResponse<UserV1Dto.UserResponse> signUp(
+			UserV1Dto.SignUpRequest signUpRequest
+	);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserInfo;
+import com.loopers.domain.user.constant.Gender;
+import jakarta.validation.constraints.NotNull;
+
+public class UserV1Dto {
+	public record SignUpRequest(
+			@NotNull
+			String userId,
+			@NotNull
+			String name,
+			@NotNull
+			Gender gender,
+			@NotNull
+			String birth,
+			@NotNull
+			String email
+	) { }
+
+	public record UserResponse(
+			String userId,
+			String name,
+			Gender gender,
+			String birth,
+			String email
+	) {
+		public static UserResponse from(UserInfo userInfo) {
+			return new UserResponse(
+					userInfo.userId(),
+					userInfo.name(),
+					userInfo.gender(),
+					userInfo.birth(),
+					userInfo.email()
+			);
+		}
+	}
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntgTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntgTest.java
@@ -1,0 +1,123 @@
+package com.loopers.domain.user;
+
+import com.loopers.application.user.UserInfo;
+import com.loopers.domain.user.constant.Gender;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+public class UserServiceIntgTest {
+	/**
+	 * 회원 가입 통합 테스트
+	 * - [x]  회원 가입시 User 저장이 수행된다. ( spy 검증 )
+	 * - [x]  이미 가입된 ID 로 회원가입 시도 시, 실패한다.
+	 */
+	@Autowired
+	private UserService userService;
+
+
+	@MockitoSpyBean
+	private UserRepository userRepository;
+
+	@Autowired
+	private DatabaseCleanUp databaseCleanUp;
+
+	@AfterEach
+	void tearDown() {
+		databaseCleanUp.truncateAllTables();
+	}
+
+	@DisplayName("회원 가입 통합 테스트")
+	@Nested
+	class Join{
+		@DisplayName("회원 가입시 User 저장이 수행된다. (spy 검증)")
+		@Test
+		void isUserSaveActionWhenUserSignUp() {
+			// arrange
+			final String userId = "tempUser";
+			final String name = "량호";
+			final Gender gender = Gender.M;
+			final String birth = "2020-12-12";
+			final String email = "temp@gmail.com";
+
+			UserV1Dto.SignUpRequest signUpRequest = new UserV1Dto.SignUpRequest(
+					userId,
+					name,
+					gender,
+					birth,
+					email
+			);
+
+			ArgumentCaptor<UserEntity> userEntityArgumentCaptor = ArgumentCaptor.forClass(UserEntity.class);
+
+			// act
+			UserInfo user = userService.createUser(signUpRequest);
+			UserV1Dto.UserResponse userResponse = UserV1Dto.UserResponse.from(user);
+
+			// assert
+			assertAll(
+					() -> assertThat(userResponse.userId()).isEqualTo(userId),
+					() -> assertThat(userResponse.email()).isEqualTo(email)
+			);
+
+			verify(userRepository, times(1)).createUser(userEntityArgumentCaptor.capture());
+			UserEntity capturedUser = userEntityArgumentCaptor.getValue();
+			assertThat(capturedUser.getUserId()).isEqualTo(userId);
+			assertThat(capturedUser.getEmail()).isEqualTo(email);
+		}
+
+		@DisplayName("이미 가입된 ID 로 회원가입 시도 시, 실패한다.")
+		@Test
+		void failTestWhenJoinByIdAlreadyJoined() {
+		    // arrange
+			final String userId1 = "tempUser";
+			final String userId2 = "tempUser";
+			final String name = "량호";
+			final Gender gender = Gender.M;
+			final String birth = "2020-12-12";
+			final String email = "temp@gmail.com";
+
+			UserV1Dto.SignUpRequest signUpRequest1 = new UserV1Dto.SignUpRequest(
+					userId1,
+					name,
+					gender,
+					birth,
+					email
+			);
+
+			UserV1Dto.SignUpRequest signUpRequest2 = new UserV1Dto.SignUpRequest(
+					userId2,
+					name,
+					gender,
+					birth,
+					email
+			);
+
+			// act
+			userService.createUser(signUpRequest1);
+
+		    // assert
+			assertThrows(CoreException.class, () -> userService.createUser(signUpRequest2));
+
+
+		}
+
+	}
+
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,0 +1,82 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.user.constant.Gender;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class UserTest {
+	/**
+	 * 회원가입 단위 테스트
+	 * - [x]  ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.
+	 * - [x]  이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.
+	 * - [x]  생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.
+	 */
+	@DisplayName("ID 가 영문 및 숫자 10자 이내 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"",
+			"aklsdjfnasdlkfjnasdlfjkn12345",
+			"한글아이디",
+	})
+	void fail_whenIdFOrmatisInvalid(String userId) {
+		// arrange
+		final String name = "량호";
+		final Gender gender = Gender.M;
+		final String email = "temp@gmail.com";
+		final String birth = "2000-12-34";
+
+		// act
+		final CoreException exception = assertThrows(CoreException.class, () -> {
+			new UserEntity(userId, name, gender, email, birth);
+		});
+
+		// assert
+		assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+	}
+
+	@DisplayName("이메일이 xx@yy.zz 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+	@Test
+	void fail_whenEmailFormatIsInvalid() {
+		// arrange
+		final String userId = "tempUser";
+		final String name = "량호";
+		final Gender gender = Gender.M;
+		final String email = "email";
+		final String birth = "2020-12-12";
+
+		// act
+		CoreException exception = assertThrows(CoreException.class, () -> {
+			new UserEntity(userId, name, gender, email, birth);
+		});
+
+		// assert
+		assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+	}
+
+	@DisplayName("생년월일이 yyyy-MM-dd 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+	@Test
+	void fail_whenBirthFormatIsInvalid() {
+		// arrange
+		final String userId = "tempUser";
+		final String name = "량호";
+		final Gender gender = Gender.M;
+		final String email = "temp@gmail.com";
+		final String birth = "2020.12.31";
+
+		// act
+		CoreException exception = assertThrows(CoreException.class, () -> {
+			new UserEntity(userId, name, gender, email, birth);
+		});
+
+		// assert
+		assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+	}
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,0 +1,97 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.domain.user.constant.Gender;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class UserV1ApiE2ETest {
+	/**
+	 * 회원가입 E2E 테스트
+	 * - [x]  회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
+	 * - [x]  회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.
+	 */
+
+	@Autowired
+	private TestRestTemplate testRestTemplate;
+
+	@Autowired
+	private DatabaseCleanUp databaseCleanUp;
+
+	@AfterEach
+	void tearDown() {
+		databaseCleanUp.truncateAllTables();
+	}
+
+	@DisplayName("POST /api/v1/users")
+	@Nested
+	class Join {
+		public static final String ENDPOINT = "/api/v1/users";
+
+		@DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 반환한다.")
+		@Test
+		void returnsUserInfo_whenJoinIsSuccessful() {
+			// arrange
+			UserV1Dto.SignUpRequest signUpRequest = new UserV1Dto.SignUpRequest(
+					"tempUser",
+					"량호",
+					Gender.M,
+					"1234-12-34",
+					"tempUser@gmail.com"
+			);
+
+			// act
+			ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType =
+					new ParameterizedTypeReference<>() {};
+			ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+					testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(signUpRequest), responseType);
+
+			// assert
+			assertAll(
+					() -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+					() -> assertThat(response.getBody()).isNotNull(),
+					() -> assertThat(response.getBody().data().userId()).isEqualTo(signUpRequest.userId()),
+					() -> assertThat(response.getBody().data().name()).isEqualTo(signUpRequest.name())
+			);
+		}
+
+		@DisplayName("회원 가입 시에 성별이 없을 경우, 400 Bad Request를 반환한다.")
+		@Test
+		void returnsBadRequest_whenGenderIsMissing() {
+			// arrange
+			UserV1Dto.SignUpRequest signUpRequest = new UserV1Dto.SignUpRequest(
+					"tempUser",
+					"량호",
+					null,
+					"1234-12-34",
+					"tempUser@gmail.com"
+			);
+
+			// act
+			ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType =
+					new ParameterizedTypeReference<>() {};
+
+			ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+					testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(signUpRequest), responseType);
+
+			// assert
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+		}
+	}
+}


### PR DESCRIPTION
## 📌 Summary
회원가입 API 구현 및 테스트 작성

## 💬 Review Points
 - 기본기 부족으로 인해 예제 코드 및 7월14일 라이브 세션을 적극 참고하여 개발 진행하였습니다.
 - [volume-1] 을 통해 테스트 및 과제 해결에 대한 전반적인 감을 키울 수 있었습니다.
 
## ✅ Checklist
    ### 회원 가입

**🧱 단위 테스트**

- [x]  ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [x]  이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [x]  생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.

**🔗 통합 테스트**

- [x]  회원 가입시 User 저장이 수행된다. ( spy 검증 )
- [x]  이미 가입된 ID 로 회원가입 시도 시, 실패한다.

**🌐 E2E 테스트**

- [x]  회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
- [x]  회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.