### PR TITLE
[volume-2] 유저 정보 조회 및 테스트

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -1,8 +1,12 @@
 package com.loopers.application.user;
 
+import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.integration.IntegrationProperties;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -11,6 +15,16 @@ public class UserFacade {
 	private final UserService userService;
 
 	public UserInfo createUser(UserV1Dto.SignUpRequest signUpRequest) {
-		return userService.createUser(signUpRequest);
+        return userService.createUser(signUpRequest);
 	}
+
+    public UserInfo getUserInfo(String userId) {
+        UserEntity user = userService.getUser(userId);
+        if (user == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+        }
+        return UserInfo.from(user);
+    }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -29,7 +29,7 @@ public class UserEntity extends BaseEntity {
 	public static final String PATTERN_EMAIL = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
 	public static final String PATTERN_BIRTH = "^\\d{4}-\\d{2}-\\d{2}$";
 
-	UserEntity(
+	public UserEntity(
 			String userId,
 			String name,
 			Gender gender,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -5,4 +5,5 @@ import java.util.Optional;
 public interface UserRepository {
 
 	Optional<UserEntity> createUser(UserEntity userEntity);
+    Optional<UserEntity> findByUserId(String userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -11,21 +11,28 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Component
 public class UserService {
-	private final UserRepository userRepository;
+    private final UserRepository userRepository;
 
-	@Transactional
-	public UserInfo createUser(UserV1Dto.SignUpRequest signUpRequest){
-		UserEntity userEntity = new UserEntity(signUpRequest.userId(),
-				signUpRequest.name(),
-				signUpRequest.gender(),
-				signUpRequest.email(),
-				signUpRequest.birth());
+    @Transactional
+    public UserInfo createUser(UserV1Dto.SignUpRequest signUpRequest) {
+        UserEntity userEntity = new UserEntity(signUpRequest.userId(),
+                signUpRequest.name(),
+                signUpRequest.gender(),
+                signUpRequest.email(),
+                signUpRequest.birth());
 
-		UserEntity user
-				= userRepository.createUser(userEntity).orElseThrow(()->{
-			return new CoreException(ErrorType.BAD_REQUEST, "회원 가입에 실패하였습니다.");
-		});
+        UserEntity user
+                = userRepository.createUser(userEntity)
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "회원 가입에 실패하였습니다."));
 
-		return UserInfo.from(user);
-	}
+        return UserInfo.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public UserEntity getUser(String userId) {
+        return userRepository.findByUserId(userId).orElse(null);
+
+    }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -3,6 +3,9 @@ package com.loopers.infrastructure.user;
 import com.loopers.domain.user.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByUserId(String userId);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -21,4 +21,9 @@ public class UserRepositoryImpl implements UserRepository {
 			return Optional.empty();
 		}
 	}
+
+    @Override
+    public Optional<UserEntity> findByUserId(String userId) {
+        return userJpaRepository.findByUserId(userId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
@@ -5,27 +5,35 @@ import com.loopers.application.user.UserInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/users")
 public class UserV1ApiController implements UserV1ApiSpec {
 
-	private final UserFacade userFacade;
+    private final UserFacade userFacade;
 
-	@PostMapping
-	@Override
-	public ApiResponse<UserV1Dto.UserResponse> signUp(
-			@RequestBody @Valid UserV1Dto.SignUpRequest signUpRequest) {
+    @PostMapping
+    @Override
+    public ApiResponse<UserV1Dto.UserResponse> signUp(
+            @RequestBody @Valid UserV1Dto.SignUpRequest signUpRequest) {
 
-		UserInfo user = userFacade.createUser(signUpRequest);
-		UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(user);
-		return ApiResponse.success(response);
+        UserInfo userInfo = userFacade.createUser(signUpRequest);
+        UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
+        return ApiResponse.success(response);
 
-	}
+    }
 
+    @GetMapping("/{userId}")
+    @Override
+    public ApiResponse<UserV1Dto.UserResponse> getUserInfo(
+            @PathVariable(value = "userId") String userId
+    ) {
+
+        UserInfo userInfo = userFacade.getUserInfo(userId);
+        UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
+
+        return ApiResponse.success(response);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -2,14 +2,22 @@ package com.loopers.interfaces.api.user;
 
 import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "User V1 API", description = "사용자 API 입니다.")
 public interface UserV1ApiSpec {
 
-	@Operation(summary = "회원 가입")
-	ApiResponse<UserV1Dto.UserResponse> signUp(
-			UserV1Dto.SignUpRequest signUpRequest
-	);
+    @Operation(summary = "회원 가입")
+    ApiResponse<UserV1Dto.UserResponse> signUp(
+            UserV1Dto.SignUpRequest signUpRequest
+    );
+
+    @Operation(summary = "유저 정보 조회", description = "유저 정보를 조회합니다.")
+    ApiResponse<UserV1Dto.UserResponse> getUserInfo(
+            @Schema(name = "ID")
+            String userId
+    );
+
 
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "loopers-java-spring-template"
+rootProject.name = "tacoShop"
 
 include(
     ":apps:commerce-api",


### PR DESCRIPTION
## 📌 Summary
유저 정보 조회 및 테스트

## 💬 Review Points
 - TFD 전략을 활용하여 개발하였습니다.
   - E2E 테스트를 진행하며 Mock API 작성
   - TOP DOWN 방식으로 개발을 진행하고, 통합 테스트를 해결하며 Facade 레이어를 도입하고, 
     Mock API를 다시 수정함으로써 개발을 완료하였습니다.
 - 유저 정보 조회 중 예외 처리는 어떤 레이어에서 처리해야 할 것인지에 대한 고민
   - 회원 가입의 경우 중복 회원 가입에 대한 예외처리를 UserService에서 처리하였으나 
   존재하지 않는 회원을 조회하는 예외 처리는 UserFacade 레이어에서 처리하였습니다.
   - 어느 계층에서 예외를 처리해야 하는지 아직 감이 잘 오지 않지만, 통합 및 E2E 테스트를 통과하기 위해 
   - service에서는 null을 반환하고,  facade에서 예외를 처리하였습니다.
 
## ✅ Checklist
### 내 정보 조회

**🔗 통합 테스트**

- [x]  해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**

- [x]  내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.
- [x]  존재하지 않는 ID 로 조회할 경우, `404 Not Found` 응답을 반환한다.