### PR TITLE
[volume-3] 포인트 조회 및 테스트

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -26,5 +26,12 @@ public class UserFacade {
         return UserInfo.from(user);
     }
 
+    public Long getUserPoint(String userId) {
+        Long point = userService.getUserPoint(userId);
+        if (point == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+        }
+        return point;
+    }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -24,6 +24,8 @@ public class UserEntity extends BaseEntity {
 	private String birth;
 	@Column(nullable = false)
 	private String email;
+    @Column(nullable = false)
+    private Long point = 0L;
 
 	public static final String PATTERN_USER_ID = "^[a-zA-Z0-9]{1,10}$";
 	public static final String PATTERN_EMAIL = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -31,7 +31,12 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserEntity getUser(String userId) {
         return userRepository.findByUserId(userId).orElse(null);
+    }
 
+    @Transactional(readOnly = true)
+    public Long getUserPoint(String userId) {
+        UserEntity user = userRepository.findByUserId(userId).orElse(null);
+        return user != null ? user.getPoint() : null;
     }
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -31,16 +32,23 @@ public class ApiControllerAdvice {
     }
 
     @ExceptionHandler
-	public ResponseEntity<ApiResponse<?>> handle(MethodArgumentNotValidException e) {
-		String message = e.getBindingResult().getFieldErrors().stream()
-				.findFirst()
-				.map(error -> error.getDefaultMessage())
-				.orElse("잘못된 요청입니다.");
+    public ResponseEntity<ApiResponse<?>> handle(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getDefaultMessage())
+                .orElse("잘못된 요청입니다.");
 
-		return failureResponse(ErrorType.BAD_REQUEST, message);
-	}
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
 
-	@ExceptionHandler
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingRequestHeaderException e) {
+        String headerName = e.getHeaderName();
+        String message = String.format("필수 요청 헤더 '%s'가 누락되었습니다.", headerName);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
     public ResponseEntity<ApiResponse<?>> handleBadRequest(MethodArgumentTypeMismatchException e) {
         String name = e.getName();
         String type = e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown";

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
@@ -36,4 +36,14 @@ public class UserV1ApiController implements UserV1ApiSpec {
 
         return ApiResponse.success(response);
     }
+
+    @GetMapping("/points")
+    @Override
+    public ApiResponse<Long> getUserPoint(@RequestHeader(name = "X-USER-ID") String headerUserId) {
+        Long point = userFacade.getUserPoint(headerUserId);
+
+        return ApiResponse.success(point);
+    }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -4,6 +4,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "User V1 API", description = "사용자 API 입니다.")
 public interface UserV1ApiSpec {
@@ -17,6 +18,12 @@ public interface UserV1ApiSpec {
     ApiResponse<UserV1Dto.UserResponse> getUserInfo(
             @Schema(name = "ID")
             String userId
+    );
+
+    @Operation(summary = "포인트 조회")
+    ApiResponse<Long> getUserPoint(
+            @Schema(name = "X-USER-ID")
+            @RequestHeader(name = "X-USER-ID") String headerUserId
     );
 
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntgTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntgTest.java
@@ -3,6 +3,7 @@ package com.loopers.domain.user;
 import com.loopers.application.user.UserInfo;
 import com.loopers.domain.user.constant.Gender;
 import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.utils.DatabaseCleanUp;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.util.function.Function;
@@ -166,4 +169,46 @@ public class UserServiceIntgTest {
             assertThat(user).isNull();
         }
     }
+
+    /**
+     * 포인트 조회
+     * - [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
+     * - [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.
+     */
+    @DisplayName("GET /api/v1/users/points")
+    @Nested
+    class FindPoint {
+        public static final String ENDPOINT = "/api/v1/users/points";
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void returnsPoint_whenUserExists() {
+            // arrange
+            String userId = "tempUser";
+            String email = "tempUser@gmail.com";
+            UserEntity savedUser = userJpaRepository.save(
+                    new UserEntity(userId, "량호", Gender.M, email, "2020-12-12")
+            );
+
+            // act
+            Long point = userService.getUserPoint(userId);
+
+            // assert
+            assertThat(point).isEqualTo(savedUser.getPoint());
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnsNull_whenUserDoesNotExist() {
+            // arrange
+            String invalidUserId = "emptyUserId";
+
+            // act
+            Long point = userService.getUserPoint(invalidUserId);
+
+            // assert
+            assertThat(point).isNull();
+        }
+    }
+
 }


### PR DESCRIPTION
## 📌 Summary
[volume-3] 포인트 조회 및 테스트

## 💬 Review Points
 - UserEntity에 point 컬럼을 추가하였습니다.
 - X-USER-ID 헤더가 없을 경우 발생하는 예외 처리를 ApiControllerAdvice에서 핸들링 하였습니다.
 
## ✅ Checklist
### 내 정보 조회

**🔗 통합 테스트**

- [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**

- [x]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
- [x]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.