### PR TITLE
[volume-4] 포인트 충전 및 테스트

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -6,7 +6,6 @@ import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.integration.IntegrationProperties;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -33,5 +32,9 @@ public class UserFacade {
         }
         return point;
     }
+
+	public Long chargePoint(String userId, UserV1Dto.PointRequest pointRequest) {
+		return userService.chargePoint(userId, pointRequest);
+	}
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -56,4 +56,11 @@ public class UserEntity extends BaseEntity {
 		this.email = email;
 		this.birth = birth;
 	}
+
+	public void addPoint(Long amount) {
+		if (amount <= 0){
+			throw new CoreException(ErrorType.BAD_REQUEST, "0 이하의 점수로 포인트를 충전 시 실패합니다.");
+		}
+		this.point += amount;
+	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -39,5 +39,13 @@ public class UserService {
         return user != null ? user.getPoint() : null;
     }
 
+	@Transactional
+	public Long chargePoint(String userId, UserV1Dto.PointRequest pointRequest) {
+		UserEntity user = userRepository.findByUserId(userId)
+				.orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+		user.addPoint(pointRequest.amount());
+		return user.getPoint();
+	}
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
@@ -45,5 +45,13 @@ public class UserV1ApiController implements UserV1ApiSpec {
         return ApiResponse.success(point);
     }
 
+	@PostMapping("/points")
+	@Override
+	public ApiResponse<UserV1Dto.PointResponse> chargePoint(@RequestHeader (name = "X-USER-ID") String headerUserId,
+															UserV1Dto.PointRequest pointRequest) {
+		Long totalPoint = userFacade.chargePoint(headerUserId, pointRequest);
+		UserV1Dto.PointResponse pointResponse = new UserV1Dto.PointResponse(totalPoint);
+		return ApiResponse.success(pointResponse);
+	}
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -4,6 +4,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "User V1 API", description = "사용자 API 입니다.")
@@ -26,5 +27,11 @@ public interface UserV1ApiSpec {
             @RequestHeader(name = "X-USER-ID") String headerUserId
     );
 
+	@Operation(summary = "포인트 충전")
+	ApiResponse<UserV1Dto.PointResponse> chargePoint(
+			@Schema(name = "X-USER-ID")
+			@RequestHeader(name = "X-USER-ID") String headerUserId,
+			@RequestBody UserV1Dto.PointRequest pointRequest
+	);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -36,4 +36,11 @@ public class UserV1Dto {
 		}
 	}
 
+	public record PointRequest(Long amount){ }
+
+	public record PointResponse(Long totalAmount){
+		public static PointResponse from(Long totalAmount) {
+			return new PointResponse(totalAmount);
+		}
+	}
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntgTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntgTest.java
@@ -6,6 +6,7 @@ import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -210,5 +211,32 @@ public class UserServiceIntgTest {
             assertThat(point).isNull();
         }
     }
+
+	/**
+	 * 포인트 충전
+	 * - [x] 존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.
+	 */
+	@DisplayName("POST /api/v1/users/points")
+	@Nested
+	class ChargePoint{
+
+		@DisplayName("존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.")
+		@Test
+		void fail_whenNotUserChargePoint() {
+			// arrange
+			UserV1Dto.PointRequest pointRequest = new UserV1Dto.PointRequest(1000L);
+			String notUserId = "notUser";
+
+		    // act
+			CoreException exception = assertThrows(CoreException.class, () -> {
+				userService.chargePoint(notUserId, pointRequest);
+			});
+
+			// assert
+			assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+
+		}
+
+	}
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -79,4 +79,25 @@ public class UserTest {
 		// assert
 		assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
 	}
+
+	/**
+	 * 포인트 충전 단위 테스트
+	 * - [x] 0 이하의 정수로 포인트를 충전 시 실패한다
+	 */
+	@DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다")
+	@ParameterizedTest
+	@ValueSource(longs = {0,-1000})
+	void fail_whenAddingPointAmountIsZeroOrNegative(Long amount) {
+	    // arrange
+		UserEntity user = new UserEntity("tempUser", "량호", Gender.M, "temp@gmail.com", "2020-12-12");
+	    
+	    // act
+		CoreException exception = assertThrows(CoreException.class, () -> {
+			user.addPoint(amount);
+		});
+
+		// assert
+		assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+	    
+	}
 }


### PR DESCRIPTION
## 📌 Summary
[volume-4] 포인트 충전 및 테스트

## 💬 Review Points
 - 기존 포인트 조회 시 단순히 Long 타입으로 반환하였으며, 충전 이후 총 보유 포인트 조회 시 PointResponse 객체로 감싸 반환하였습니다.
   - 어느덧 UserFacade 에서 반환타입들이 엉망으로 되어있는것을 보아 리팩토링의 필요성을 느꼈습니다.   
 -  TFD 전략을 활용하여 개발 하였는데, 어느 새 UserService와 UserFacade에 예외처리가 나뉘어졌습니다. 
   에러 처리를 어디서 해야 할 지 고민하다가 .. 우선 구현 및 테스트 성공에 집중하였습니다!
   
## ✅ Checklist
### 포인트 충전

**🧱 단위 테스트**

- [x]  0 이하의 정수로 포인트를 충전 시 실패한다.

**🔗 통합 테스트**

- [x] 존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.

**🌐 E2E 테스트**

- [x]  존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.
- [x]  존재하지 않는 유저로 요청할 경우, `404 Not Found` 응답을 반환한다.