### PR TITLE
[volume-20] Round8: Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ docker-compose -f ./docker/monitoring-compose.yml up
 ```
 Root
 ├── apps ( spring-applications )
-│   └── 📦 commerce-api
+│   ├── 📦 commerce-api
+│   └── 📦 commerce-streamer
 ├── modules ( reusable-configurations )
-│   └── 📦 jpa
+│   ├── 📦 jpa
+│   ├── 📦 redis
+│   └── 📦 kafka
 └── supports ( add-ons )
+    ├── 📦 jackson
     ├── 📦 monitoring
     └── 📦 logging
 ```

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
     implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))

--- a/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsCommand.java
@@ -1,0 +1,11 @@
+package com.loopers.application.metrics;
+
+public record ProductMetricsCommand(
+		Long ProductId,
+		String eventType,
+		int delta
+) {
+	public static ProductMetricsCommand of(Long productId, String eventType, int delta) {
+		return new ProductMetricsCommand(productId, eventType, delta);
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsCommand.java
@@ -1,11 +1,12 @@
 package com.loopers.application.metrics;
 
 public record ProductMetricsCommand(
+		String eventId,
 		Long ProductId,
 		String eventType,
 		int delta
 ) {
-	public static ProductMetricsCommand of(Long productId, String eventType, int delta) {
-		return new ProductMetricsCommand(productId, eventType, delta);
+	public static ProductMetricsCommand of(String eventId, Long productId, String eventType, int delta) {
+		return new ProductMetricsCommand(eventId, productId, eventType, delta);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsEventHandler.java
@@ -1,0 +1,58 @@
+package com.loopers.application.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.like.event.LikeEventType;
+import com.loopers.domain.like.event.ProductLikeEvent;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderDomainService;
+import com.loopers.domain.order.OrderProduct;
+import com.loopers.domain.payment.event.PaymentOrderSuccessEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductMetricsEventHandler {
+
+	@Value("${kafka.topic.product-metrics}")
+	private String productMetricsTopic;
+
+	private final KafkaTemplate<Object, Object> kafkaTemplate;
+
+	private final OrderDomainService orderDomainService;
+
+	public void handleLikeMetrics(ProductLikeEvent event){
+		int delta = event.likeEventType().equals(LikeEventType.LIKE) ? 1 : -1;
+		ProductMetricsCommand productMetricsCommand = ProductMetricsCommand.of(event.productId(), event.getEventType(), delta);
+
+		sendMetrics(productMetricsCommand);
+	}
+
+	public void handleStockMetrics(PaymentOrderSuccessEvent event){
+		Order order = orderDomainService.getOrder(event.orderId());
+		List<OrderProduct> orderProducts = order.getOrderProducts();
+		List<ProductMetricsCommand> productMetricsCommandList = orderProducts.stream()
+				.map(item -> ProductMetricsCommand.of(item.getProductId(), event.getEventType(), item.getQuantity()))
+				.toList();
+
+		for (ProductMetricsCommand productMetricsCommand : productMetricsCommandList) {
+			sendMetrics(productMetricsCommand);
+		}
+	}
+
+	public void handleViewMetrics(ProductViewedEvent event){
+		ProductMetricsCommand productMetricsCommand = ProductMetricsCommand.of(event.productId(), event.getEventType(), 1);
+
+		sendMetrics(productMetricsCommand);
+	}
+
+	public void sendMetrics(ProductMetricsCommand productMetricsCommand){
+		kafkaTemplate.send(productMetricsTopic, productMetricsCommand);
+	}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsEventHandler.java
@@ -1,6 +1,5 @@
 package com.loopers.application.metrics;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.domain.like.event.LikeEventType;
 import com.loopers.domain.like.event.ProductLikeEvent;
 import com.loopers.domain.order.Order;

--- a/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsEventHandler.java
@@ -27,7 +27,7 @@ public class ProductMetricsEventHandler {
 
 	public void handleLikeMetrics(ProductLikeEvent event){
 		int delta = event.likeEventType().equals(LikeEventType.LIKE) ? 1 : -1;
-		ProductMetricsCommand productMetricsCommand = ProductMetricsCommand.of(event.productId(), event.getEventType(), delta);
+		ProductMetricsCommand productMetricsCommand = ProductMetricsCommand.of(event.eventId(), event.productId(), event.getEventType(), delta);
 
 		sendMetrics(productMetricsCommand);
 	}
@@ -36,7 +36,7 @@ public class ProductMetricsEventHandler {
 		Order order = orderDomainService.getOrder(event.orderId());
 		List<OrderProduct> orderProducts = order.getOrderProducts();
 		List<ProductMetricsCommand> productMetricsCommandList = orderProducts.stream()
-				.map(item -> ProductMetricsCommand.of(item.getProductId(), event.getEventType(), item.getQuantity()))
+				.map(item -> ProductMetricsCommand.of(event.eventId(), item.getProductId(), event.getEventType(), item.getQuantity()))
 				.toList();
 
 		for (ProductMetricsCommand productMetricsCommand : productMetricsCommandList) {
@@ -45,7 +45,7 @@ public class ProductMetricsEventHandler {
 	}
 
 	public void handleViewMetrics(ProductViewedEvent event){
-		ProductMetricsCommand productMetricsCommand = ProductMetricsCommand.of(event.productId(), event.getEventType(), 1);
+		ProductMetricsCommand productMetricsCommand = ProductMetricsCommand.of(event.eventId(), event.productId(), event.getEventType(), 1);
 
 		sendMetrics(productMetricsCommand);
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductService.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandDomainService;
 import com.loopers.domain.product.*;
+import com.loopers.domain.product.event.ProductViewedEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,7 @@ public class ProductService {
 	private final BrandDomainService brandDomainService;
 	private final ProductCacheRepository productCacheRepository;
 	private final ObjectMapper objectMapper;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional(readOnly = true)
 	public ProductListInfo getProductList(ProductQuery productQuery) {
@@ -67,6 +70,8 @@ public class ProductService {
 		Brand brand = brandDomainService.getBrand(product.getBrandId()).orElse(null);
 
 		ProductDetail productDetail = productDomainService.assembleProductDetail(product, brand);
+		eventPublisher.publishEvent(ProductViewedEvent.of(productId));
+
 		return ProductInfo.from(productDetail);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/event/ProductLikeEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/event/ProductLikeEventHandler.java
@@ -3,6 +3,7 @@ package com.loopers.application.product.event;
 import com.loopers.domain.like.event.LikeEventType;
 import com.loopers.domain.like.event.ProductLikeEvent;
 import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductCacheRepository;
 import com.loopers.domain.product.ProductDomainService;
 import com.loopers.domain.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +13,15 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class ProductLikeEventHandler {
 
 	private final ProductDomainService productDomainService;
 	private final ProductRepository productRepository;
+	private final ProductCacheRepository productCacheRepository;
 
 	@Retryable(
 			retryFor = ObjectOptimisticLockingFailureException.class,
@@ -34,6 +38,15 @@ public class ProductLikeEventHandler {
 			product.decreaseLikeCount();
 
 		productRepository.save(product);
+	}
+
+	public void handleLikeCache(){
+		List<String> keys = List.of(
+				"product-list-sortType:likes_desc-page:0-size:10",
+				"product-list-sortType:likes_desc-page:1-size:10"
+		);
+
+		productCacheRepository.delete(keys);
 	}
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/event/ProductLikeEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/event/ProductLikeEventHandler.java
@@ -40,7 +40,7 @@ public class ProductLikeEventHandler {
 		productRepository.save(product);
 	}
 
-	public void handleLikeCache(){
+	public void cacheClearByLikeChanged(){
 		List<String> keys = List.of(
 				"product-list-sortType:likes_desc-page:0-size:10",
 				"product-list-sortType:likes_desc-page:1-size:10"

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/DomainEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/DomainEvent.java
@@ -1,6 +1,10 @@
 package com.loopers.domain.event;
 
+import org.apache.kafka.common.protocol.types.Field;
+
 public interface DomainEvent {
+	String eventId();
+	
 	default String getEventType() {
 		return this.getClass().getSimpleName();
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/DomainEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/DomainEvent.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.event;
+
+public interface DomainEvent {
+	default String getEventType() {
+		return this.getClass().getSimpleName();
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductLikeEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductLikeEvent.java
@@ -3,12 +3,15 @@ package com.loopers.domain.like.event;
 import com.loopers.domain.event.DomainEvent;
 import com.loopers.domain.like.Like;
 
+import java.util.UUID;
+
 public record ProductLikeEvent(
+		String eventId,
 		Long productId,
 		Long userId,
 		LikeEventType likeEventType
 ) implements DomainEvent {
 	public static ProductLikeEvent of(Like like, LikeEventType likeEventType) {
-		return new ProductLikeEvent(like.getProductId(), like.getUserId(), likeEventType);
+		return new ProductLikeEvent(UUID.randomUUID().toString(), like.getProductId(), like.getUserId(), likeEventType);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductLikeEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductLikeEvent.java
@@ -1,12 +1,13 @@
 package com.loopers.domain.like.event;
 
+import com.loopers.domain.event.DomainEvent;
 import com.loopers.domain.like.Like;
 
 public record ProductLikeEvent(
 		Long productId,
 		Long userId,
 		LikeEventType likeEventType
-) {
+) implements DomainEvent {
 	public static ProductLikeEvent of(Like like, LikeEventType likeEventType) {
 		return new ProductLikeEvent(like.getProductId(), like.getUserId(), likeEventType);
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
@@ -3,7 +3,10 @@ package com.loopers.domain.order.event;
 import com.loopers.domain.event.DomainEvent;
 import com.loopers.domain.order.Order;
 
+import java.util.UUID;
+
 public record OrderCreatedEvent(
+		String eventId,
 		Long userId,
 		Long orderId,
 		int finalPrice,
@@ -12,6 +15,7 @@ public record OrderCreatedEvent(
 ) implements DomainEvent {
 	public static OrderCreatedEvent from(Order order) {
 		return new OrderCreatedEvent(
+				UUID.randomUUID().toString(),
 				order.getUserId(),
 				order.getId(),
 				order.getFinalPrice(),

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.order.event;
 
+import com.loopers.domain.event.DomainEvent;
 import com.loopers.domain.order.Order;
 
 public record OrderCreatedEvent(
@@ -8,7 +9,7 @@ public record OrderCreatedEvent(
 		int finalPrice,
 		int discountAmount,
 		Long couponId
-) {
+) implements DomainEvent {
 	public static OrderCreatedEvent from(Order order) {
 		return new OrderCreatedEvent(
 				order.getUserId(),

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentOrderFailEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentOrderFailEvent.java
@@ -2,12 +2,15 @@ package com.loopers.domain.payment.event;
 
 import com.loopers.domain.event.DomainEvent;
 
+import java.util.UUID;
+
 public record PaymentOrderFailEvent(
+		String eventId,
 		Long paymentId,
 		String userId,
 		Long orderId
 ) implements DomainEvent {
 	public static PaymentOrderFailEvent of(Long paymentId, String userId, Long orderId) {
-		return new PaymentOrderFailEvent(paymentId, userId, orderId);
+		return new PaymentOrderFailEvent(UUID.randomUUID().toString(), paymentId, userId, orderId);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentOrderFailEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentOrderFailEvent.java
@@ -1,10 +1,12 @@
 package com.loopers.domain.payment.event;
 
+import com.loopers.domain.event.DomainEvent;
+
 public record PaymentOrderFailEvent(
 		Long paymentId,
 		String userId,
 		Long orderId
-) {
+) implements DomainEvent {
 	public static PaymentOrderFailEvent of(Long paymentId, String userId, Long orderId) {
 		return new PaymentOrderFailEvent(paymentId, userId, orderId);
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentOrderSuccessEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentOrderSuccessEvent.java
@@ -2,12 +2,15 @@ package com.loopers.domain.payment.event;
 
 import com.loopers.domain.event.DomainEvent;
 
+import java.util.UUID;
+
 public record PaymentOrderSuccessEvent(
+		String eventId,
 		Long paymentId,
 		String userId,
 		Long orderId
 ) implements DomainEvent {
 	public static PaymentOrderSuccessEvent of(Long paymentId, String userId, Long orderId) {
-		return new PaymentOrderSuccessEvent(paymentId, userId, orderId);
+		return new PaymentOrderSuccessEvent(UUID.randomUUID().toString(), paymentId, userId, orderId);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentOrderSuccessEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentOrderSuccessEvent.java
@@ -1,10 +1,12 @@
 package com.loopers.domain.payment.event;
 
+import com.loopers.domain.event.DomainEvent;
+
 public record PaymentOrderSuccessEvent(
 		Long paymentId,
 		String userId,
 		Long orderId
-) {
+) implements DomainEvent {
 	public static PaymentOrderSuccessEvent of(Long paymentId, String userId, Long orderId) {
 		return new PaymentOrderSuccessEvent(paymentId, userId, orderId);
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentRequestFailEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentRequestFailEvent.java
@@ -1,9 +1,11 @@
 package com.loopers.domain.payment.event;
 
-public record PaymentRequestFailEvent (
+import com.loopers.domain.event.DomainEvent;
+
+public record PaymentRequestFailEvent(
 		String userId,
 		Long orderId
-){
+) implements DomainEvent {
 	public static PaymentRequestFailEvent of(String userId, Long orderId) {
 		return new PaymentRequestFailEvent(userId, orderId);
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentRequestFailEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentRequestFailEvent.java
@@ -2,11 +2,14 @@ package com.loopers.domain.payment.event;
 
 import com.loopers.domain.event.DomainEvent;
 
+import java.util.UUID;
+
 public record PaymentRequestFailEvent(
+		String eventId,
 		String userId,
 		Long orderId
 ) implements DomainEvent {
 	public static PaymentRequestFailEvent of(String userId, Long orderId) {
-		return new PaymentRequestFailEvent(userId, orderId);
+		return new PaymentRequestFailEvent(UUID.randomUUID().toString(), userId, orderId);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCacheKeyGenerator.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCacheKeyGenerator.java
@@ -2,6 +2,8 @@ package com.loopers.domain.product;
 
 import com.loopers.application.product.ProductQuery;
 
+import java.util.Locale;
+
 public class ProductCacheKeyGenerator {
 	public static String getKey(ProductQuery productQuery) {
 		StringBuilder keyBuilder = new StringBuilder("product-list");
@@ -11,7 +13,7 @@ public class ProductCacheKeyGenerator {
 		}
 
 		if (productQuery.getSortType() != null) {
-			keyBuilder.append("-sortType:").append(productQuery.getSortType());
+			keyBuilder.append("-sortType:").append(productQuery.getSortType().name().toLowerCase());
 		}
 
 		keyBuilder.append("-page:").append(productQuery.getPage());

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCacheRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCacheRepository.java
@@ -3,6 +3,7 @@ package com.loopers.domain.product;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.time.Duration;
+import java.util.List;
 
 public interface ProductCacheRepository {
 	String get(String cacheKey);
@@ -10,4 +11,6 @@ public interface ProductCacheRepository {
 	<T> void set(String key, T value, Duration ttl) throws JsonProcessingException;
 
 	<T> void set(String key, T value) throws JsonProcessingException;
+
+	void delete(List<String> keys);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewedEvent.java
@@ -2,10 +2,13 @@ package com.loopers.domain.product.event;
 
 import com.loopers.domain.event.DomainEvent;
 
+import java.util.UUID;
+
 public record ProductViewedEvent(
+		String eventId,
 		Long productId
 ) implements DomainEvent {
 	public static ProductViewedEvent of(Long productId) {
-		return new ProductViewedEvent(productId);
+		return new ProductViewedEvent(UUID.randomUUID().toString(), productId);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewedEvent.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.product.event;
+
+import com.loopers.domain.event.DomainEvent;
+
+public record ProductViewedEvent(
+		Long productId
+) implements DomainEvent {
+	public static ProductViewedEvent of(Long productId) {
+		return new ProductViewedEvent(productId);
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductCacheRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductCacheRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -29,6 +30,11 @@ public class ProductCacheRepositoryImpl implements ProductCacheRepository {
 	@Override
 	public <T> void set(String key, T value) throws JsonProcessingException {
 		set(key, value, Duration.ofMinutes(5));
+	}
+
+	@Override
+	public void delete(List<String> keys) {
+		redisTemplate.delete(keys);
 	}
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/outbound/AuditLogEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/outbound/AuditLogEventListener.java
@@ -22,8 +22,6 @@ public class AuditLogEventListener {
 	@Value( "${kafka.topic.audit-topic-name}")
 	private String auditTopic;
 
-	private final String EVENT_HEADER_KEY = "eventType";
-
 	private final ObjectMapper objectMapper;
 	private final KafkaTemplate<String, String> kafkaTemplate;
 
@@ -34,8 +32,10 @@ public class AuditLogEventListener {
 		try {
 			String payload = objectMapper.writeValueAsString(event);
 			String eventType = event.getEventType();
+			String eventId = event.eventId();
 			ProducerRecord<String, String> record = new ProducerRecord<>(auditTopic, payload);
-			record.headers().add(EVENT_HEADER_KEY, eventType.getBytes(StandardCharsets.UTF_8));
+			record.headers().add("eventType", eventType.getBytes(StandardCharsets.UTF_8));
+			record.headers().add("eventId", eventId.getBytes(StandardCharsets.UTF_8));
 			kafkaTemplate.send(record);
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException("Failed to serialize event");

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/outbound/AuditLogEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/outbound/AuditLogEventListener.java
@@ -1,0 +1,45 @@
+package com.loopers.interfaces.event.outbound;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.event.DomainEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuditLogEventListener {
+
+	@Value( "${kafka.topic.audit-topic-name}")
+	private String auditTopic;
+
+	private final String EVENT_HEADER_KEY = "eventType";
+
+	private final ObjectMapper objectMapper;
+	private final KafkaTemplate<String, String> kafkaTemplate;
+
+
+	@EventListener
+	public void sendMessage(DomainEvent event){
+		log.info("##### Audit Sending event: {}", event);
+		try {
+			String payload = objectMapper.writeValueAsString(event);
+			String eventType = event.getEventType();
+			ProducerRecord<String, String> record = new ProducerRecord<>(auditTopic, payload);
+			record.headers().add(EVENT_HEADER_KEY, eventType.getBytes(StandardCharsets.UTF_8));
+			kafkaTemplate.send(record);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Failed to serialize event");
+		}
+	}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/outbound/ProductMetricsEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/outbound/ProductMetricsEventListener.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.event.outbound;
+
+import com.loopers.application.metrics.ProductMetricsEventHandler;
+import com.loopers.domain.like.event.ProductLikeEvent;
+import com.loopers.domain.payment.event.PaymentOrderSuccessEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductMetricsEventListener {
+
+	private final ProductMetricsEventHandler productMetricsEventHandler;
+
+	@EventListener
+	public void handle(ProductLikeEvent event) {
+		productMetricsEventHandler.handleLikeMetrics(event);
+	}
+
+	@EventListener
+	public void handle(PaymentOrderSuccessEvent event) {
+		productMetricsEventHandler.handleStockMetrics(event);
+	}
+
+	@EventListener
+	public void handle(ProductViewedEvent event) {
+		productMetricsEventHandler.handleViewMetrics(event);
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/product/ProductEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/product/ProductEventListener.java
@@ -17,6 +17,10 @@ public class ProductEventListener {
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleProductLikeEvent(ProductLikeEvent event){
+		// 좋아요 수 업데이트
 		productLikeEventHandler.updateLikeCount(event);
+
+		// 좋아요 수 캐시 무효화
+		productLikeEventHandler.likeChanged();
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/event/product/ProductEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/event/product/ProductEventListener.java
@@ -21,6 +21,6 @@ public class ProductEventListener {
 		productLikeEventHandler.updateLikeCount(event);
 
 		// 좋아요 수 캐시 무효화
-		productLikeEventHandler.likeChanged();
+		productLikeEventHandler.cacheClearByLikeChanged();
 	}
 }

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
       - redis.yml
       - logging.yml
       - monitoring.yml
+      - kafka.yml
 
 springdoc:
   use-fqn: true
@@ -59,6 +60,11 @@ resilience4j:
         minimum-number-of-calls: 10 # 최소 호출
         wait-duration-in-open-state: 5s # 오픈 상태에서 대기 시간
         permitted-number-of-calls-in-half-open-state: 3 # HALF_OPEN 상태에서 호출 허용 수
+
+kafka:
+  topic:
+    audit-topic-name: audit.topic-v1
+    product-metrics: product.metrics-v1
 
 ---
 spring:

--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -1,0 +1,23 @@
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // querydsl
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+    testImplementation(testFixtures(project(":modules:kafka")))
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/CommerceStreamerApplication.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/CommerceStreamerApplication.java
@@ -1,0 +1,24 @@
+package com.loopers;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+import java.util.TimeZone;
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+public class CommerceStreamerApplication {
+    @PostConstruct
+    public void started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(CommerceStreamerApplication.class, args);
+    }
+}
+
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogCommand.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogCommand.java
@@ -1,0 +1,10 @@
+package com.loopers.application.auditlog;
+
+public record AuditLogCommand(
+		String eventType,
+		String payload
+) {
+	public static AuditLogCommand of(String eventType, String payload) {
+		return new AuditLogCommand(eventType, payload);
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogCommand.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogCommand.java
@@ -1,10 +1,11 @@
 package com.loopers.application.auditlog;
 
 public record AuditLogCommand(
+		String eventId,
 		String eventType,
 		String payload
 ) {
-	public static AuditLogCommand of(String eventType, String payload) {
-		return new AuditLogCommand(eventType, payload);
+	public static AuditLogCommand of(String eventId, String eventType, String payload) {
+		return new AuditLogCommand(eventId, eventType, payload);
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogService.java
@@ -2,24 +2,45 @@ package com.loopers.application.auditlog;
 
 import com.loopers.domain.auditlog.AuditLog;
 import com.loopers.domain.auditlog.AuditLogRepository;
+import com.loopers.domain.eventHandled.EventHandled;
+import com.loopers.domain.eventHandled.EventHandledRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class AuditLogService {
 
+	private final EventHandledRepository eventHandledRepository;
 	private final AuditLogRepository auditLogRepository;
 
 	@Transactional
 	public void saveAuditLog(List<AuditLogCommand> commands) {
+		// 이벤트 핸들 ID 조회
+		Set<String> handledEventIds = eventHandledRepository.findEventIds(commands.stream()
+				.map(AuditLogCommand::eventId)
+				.collect(Collectors.toSet()));
+
+		// 이미 처리 된 이벤트 제외한 감사로그 생성
 		List<AuditLog> auditLogs = commands.stream()
-				.map(command -> AuditLog.of(command.eventType(), command.payload()))
+				.filter(command -> !handledEventIds.contains(command.eventId()))
+				.map(command -> AuditLog.of(command.eventId(), command.eventType(), command.payload()))
 				.toList();
 
+		// 이벤트 핸들 리스트 생성
+		List<EventHandled> eventHandleds = auditLogs.stream()
+				.map(log -> EventHandled.of(log.getEventId()))
+				.toList();
+
+		// 감사로그 저장
 		auditLogRepository.saveAll(auditLogs);
+
+		// 이벤트 핸들 저장
+		eventHandledRepository.saveAll(eventHandleds);
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogService.java
@@ -1,0 +1,25 @@
+package com.loopers.application.auditlog;
+
+import com.loopers.domain.auditlog.AuditLog;
+import com.loopers.domain.auditlog.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AuditLogService {
+
+	private final AuditLogRepository auditLogRepository;
+
+	@Transactional
+	public void saveAuditLog(List<AuditLogCommand> commands) {
+		List<AuditLog> auditLogs = commands.stream()
+				.map(command -> AuditLog.of(command.eventType(), command.payload()))
+				.toList();
+
+		auditLogRepository.saveAll(auditLogs);
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsCommand.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsCommand.java
@@ -1,0 +1,8 @@
+package com.loopers.application.metrics;
+
+public record ProductMetricsCommand(
+		Long ProductId,
+		String eventType,
+		int delta
+) {
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsCommand.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsCommand.java
@@ -1,6 +1,7 @@
 package com.loopers.application.metrics;
 
 public record ProductMetricsCommand(
+		String eventId,
 		Long ProductId,
 		String eventType,
 		int delta

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
@@ -1,0 +1,30 @@
+package com.loopers.application.metrics;
+
+import com.loopers.domain.metrics.ProductMetricType;
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProductMetricsService {
+
+	private final ProductMetricsRepository productMetricsRepository;
+
+	public void handleMetrics(List<ProductMetricsCommand> commands) {
+		List<ProductMetrics> productMetricsList = commands.stream()
+				.map(c -> ProductMetrics.create(c.ProductId(),
+						c.eventType(),
+						ProductMetricType.from(c.eventType()),
+						c.delta()))
+				.toList();
+
+		productMetricsRepository.saveAll(productMetricsList);
+
+	}
+
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
@@ -1,32 +1,36 @@
 package com.loopers.application.metrics;
 
+import com.loopers.domain.eventHandled.EventHandledDomainService;
 import com.loopers.domain.metrics.MetricType;
 import com.loopers.domain.metrics.ProductMetrics;
-import com.loopers.domain.metrics.ProductMetricsRepository;
+import com.loopers.domain.metrics.ProductMetricsDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 
 @Component
 @RequiredArgsConstructor
 public class ProductMetricsService {
 
-	private final ProductMetricsRepository productMetricsRepository;
+	private final EventHandledDomainService eventHandledDomainService;
+	private final ProductMetricsDomainService productMetricsDomainService;
 
 	@Transactional
 	public void handleMetrics(ProductMetricsCommand command) {
+		// 이벤트 중복 처리 확인
+		if (eventHandledDomainService.isHandled(command.eventId()))
+			return;
 
-		ProductMetrics productMetrics = productMetricsRepository.findByProductIdAndDate(command.ProductId(), LocalDate.now())
-				.orElseGet(() -> ProductMetrics.of(command.ProductId()));
+		// ProductMetrics 조회
+		ProductMetrics productMetrics = productMetricsDomainService.getProductMetrics(command.ProductId());
 
-		MetricType metricType = MetricType.from(command.eventType());
-		switch (metricType) {
-			case PRODUCT_LIKE -> productMetrics.adjustLikesDelta(command.delta());
-			case PRODUCT_SALES -> productMetrics.increaseSalesDelta(command.delta());
-			case PRODUCT_VIEWED -> productMetrics.increaseViewsDelta(command.delta());
-		}
-		productMetricsRepository.save(productMetrics);
+		// ProductMetrics 업데이트
+		productMetricsDomainService.updateMetricsDeltas(productMetrics, MetricType.from(command.eventType()), command.delta());
+
+		// ProductMetrics 저장
+		productMetricsDomainService.saveMetrics(productMetrics);
+
+		// 이벤트 핸들 처리
+		eventHandledDomainService.saveEventHandled(command.eventId());
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/auditlog/AuditLog.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/auditlog/AuditLog.java
@@ -13,15 +13,16 @@ import java.time.ZonedDateTime;
 @Table(name = "event_log")
 public class AuditLog {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	@Column(name = "event_id", nullable = false, unique = true)
+	private String eventId;
 	private String eventType;
 	private String payload;
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private ZonedDateTime createdAt;
 
-	public static AuditLog of(String eventType, String payload) {
+	public static AuditLog of(String eventId, String eventType, String payload) {
 		AuditLog auditLog = new AuditLog();
+		auditLog.eventId = eventId;
 		auditLog.eventType = eventType;
 		auditLog.payload = payload;
 		auditLog.createdAt = ZonedDateTime.now();

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/auditlog/AuditLog.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/auditlog/AuditLog.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.auditlog;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "event_log")
+public class AuditLog {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String eventType;
+	private String payload;
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private ZonedDateTime createdAt;
+
+	public static AuditLog of(String eventType, String payload) {
+		AuditLog auditLog = new AuditLog();
+		auditLog.eventType = eventType;
+		auditLog.payload = payload;
+		auditLog.createdAt = ZonedDateTime.now();
+		return auditLog;
+	}
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/auditlog/AuditLogRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/auditlog/AuditLogRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.auditlog;
+
+import java.util.List;
+
+public interface AuditLogRepository {
+	AuditLog save(AuditLog auditLog);
+	List<AuditLog> saveAll(List<AuditLog> auditLogs);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandled.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandled.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.eventHandled;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "event_handled")
+public class EventHandled {
+	@Id
+	@Column(name = "event_id", nullable = false, unique = true)
+	private String eventId;
+
+	@Column(name = "processed_at")
+	private LocalDateTime processedAt;
+
+	public static EventHandled of(String eventId) {
+		EventHandled eventHandled = new EventHandled();
+		eventHandled.eventId = eventId;
+		eventHandled.processedAt = LocalDateTime.now();
+		return eventHandled;
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledDomainService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledDomainService.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.eventHandled;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class EventHandledDomainService {
+	private final EventHandledRepository eventHandledRepository;
+
+	public boolean isHandled(String eventId) {
+		return eventHandledRepository.existsByEventId(eventId);
+	}
+
+	@Transactional
+	public void saveEventHandled(String eventId) {
+		eventHandledRepository.save(EventHandled.of(eventId));
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.eventHandled;
+
+import java.util.List;
+import java.util.Set;
+
+public interface EventHandledRepository {
+	boolean existsByEventId(String eventId);
+	EventHandled save(EventHandled eventHandled);
+	Set<String> findEventIds(Set<String> eventIds);
+	List<EventHandled> saveAll(List<EventHandled> eventHandleds);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricType.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricType.java
@@ -1,17 +1,17 @@
 package com.loopers.domain.metrics;
 
-public enum ProductMetricType {
-	PRODUCT_LIKED("ProductLikeEvent"),
+public enum MetricType {
+	PRODUCT_LIKE("ProductLikeEvent"),
 	PRODUCT_VIEWED("ProductViewedEvent"),
 	PRODUCT_SALES("PaymentOrderSuccessEvent");
 
 	private final String eventType;
-	ProductMetricType(String eventType) {
+	MetricType(String eventType) {
 		this.eventType = eventType;
 	}
 
-	public static ProductMetricType from(String eventType) {
-		for (ProductMetricType type : values()) {
+	public static MetricType from(String eventType) {
+		for (MetricType type : values()) {
 			if (type.eventType.equals(eventType)) {
 				return type;
 			}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricType.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricType.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.metrics;
+
+public enum ProductMetricType {
+	PRODUCT_LIKED("ProductLikeEvent"),
+	PRODUCT_VIEWED("ProductViewedEvent"),
+	PRODUCT_SALES("PaymentOrderSuccessEvent");
+
+	private final String eventType;
+	ProductMetricType(String eventType) {
+		this.eventType = eventType;
+	}
+
+	public static ProductMetricType from(String eventType) {
+		for (ProductMetricType type : values()) {
+			if (type.eventType.equals(eventType)) {
+				return type;
+			}
+		}
+		throw new IllegalArgumentException("Invalid event type: " + eventType);
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.metrics;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,7 +10,7 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @Table(name = "product_metrics")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductMetrics {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,25 +19,34 @@ public class ProductMetrics {
 	@Column(name = "product_id", nullable = false)
 	private Long productId;
 
-	@Column(name = "event_type", nullable = false)
-	private String eventType;
+	@Column(name = "likes_delta")
+	private int likesDelta;
 
-	@Enumerated(EnumType.STRING)
-	private ProductMetricType productMetricType;
+	@Column(name = "sales_delta")
+	private int salesDelta;
 
-	private int delta;
+	@Column(name = "views_delta")
+	private int viewsDelta;
 
 	private LocalDate date;
 
-
-	public static ProductMetrics create(Long ProductId, String eventType, ProductMetricType productMetricType, int delta){
+	public static ProductMetrics of(Long productId){
 		ProductMetrics productMetrics = new ProductMetrics();
-		productMetrics.productId = ProductId;
-		productMetrics.eventType = eventType;
-		productMetrics.productMetricType = productMetricType;
-		productMetrics.delta = delta;
+		productMetrics.productId = productId;
 		productMetrics.date = LocalDate.now();
 		return productMetrics;
+	}
+
+	public void adjustLikesDelta(int delta){
+		this.likesDelta += delta;
+	}
+
+	public void increaseSalesDelta(int delta){
+		this.salesDelta += delta;
+	}
+
+	public void increaseViewsDelta(int delta){
+		this.viewsDelta += delta;
 	}
 
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,0 +1,42 @@
+package com.loopers.domain.metrics;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "product_metrics")
+@NoArgsConstructor
+public class ProductMetrics {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "product_id", nullable = false)
+	private Long productId;
+
+	@Column(name = "event_type", nullable = false)
+	private String eventType;
+
+	@Enumerated(EnumType.STRING)
+	private ProductMetricType productMetricType;
+
+	private int delta;
+
+	private LocalDate date;
+
+
+	public static ProductMetrics create(Long ProductId, String eventType, ProductMetricType productMetricType, int delta){
+		ProductMetrics productMetrics = new ProductMetrics();
+		productMetrics.productId = ProductId;
+		productMetrics.eventType = eventType;
+		productMetrics.productMetricType = productMetricType;
+		productMetrics.delta = delta;
+		productMetrics.date = LocalDate.now();
+		return productMetrics;
+	}
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsDomainService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsDomainService.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.metrics;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class ProductMetricsDomainService {
+
+	private final ProductMetricsRepository productMetricsRepository;
+
+	public ProductMetrics getProductMetrics(Long productId){
+		return productMetricsRepository.findByProductIdAndDate(productId, LocalDate.now())
+				.orElseGet(() -> ProductMetrics.of(productId));
+	}
+
+	public void updateMetricsDeltas(ProductMetrics productMetrics, MetricType metricType, int delta) {
+		switch (metricType) {
+			case PRODUCT_LIKE -> productMetrics.adjustLikesDelta(delta);
+			case PRODUCT_SALES -> productMetrics.increaseSalesDelta(delta);
+			case PRODUCT_VIEWED -> productMetrics.increaseViewsDelta(delta);
+		}
+	}
+
+	@Transactional
+	public void saveMetrics(ProductMetrics productMetrics){
+		productMetricsRepository.save(productMetrics);
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.metrics;
+
+import java.util.List;
+
+public interface ProductMetricsRepository {
+	List<ProductMetrics> saveAll(List<ProductMetrics> productMetricsList);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -1,7 +1,10 @@
 package com.loopers.domain.metrics;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductMetricsRepository {
-	List<ProductMetrics> saveAll(List<ProductMetrics> productMetricsList);
+	ProductMetrics save(ProductMetrics productMetrics);
+	Optional<ProductMetrics> findByProductIdAndDate(Long productId, LocalDate date);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/auditlog/AuditLogJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/auditlog/AuditLogJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.auditlog;
+
+import com.loopers.domain.auditlog.AuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogJpaRepository extends JpaRepository<AuditLog, Long> {
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/auditlog/AuditLogJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/auditlog/AuditLogJpaRepository.java
@@ -3,6 +3,6 @@ package com.loopers.infrastructure.auditlog;
 import com.loopers.domain.auditlog.AuditLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AuditLogJpaRepository extends JpaRepository<AuditLog, Long> {
+public interface AuditLogJpaRepository extends JpaRepository<AuditLog, String> {
 
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/auditlog/AuditLogRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/auditlog/AuditLogRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.auditlog;
+
+import com.loopers.domain.auditlog.AuditLog;
+import com.loopers.domain.auditlog.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AuditLogRepositoryImpl implements AuditLogRepository {
+	private final AuditLogJpaRepository auditLogJpaRepository;
+
+	@Override
+	public AuditLog save(AuditLog auditLog) {
+		return auditLogJpaRepository.save(auditLog);
+	}
+
+	@Override
+	public List<AuditLog> saveAll(List<AuditLog> auditLogs) {
+		return auditLogJpaRepository.saveAll(auditLogs);
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventHandled/EventHandledJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventHandled/EventHandledJpaRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.infrastructure.eventHandled;
+
+import com.loopers.domain.eventHandled.EventHandled;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Set;
+
+public interface EventHandledJpaRepository extends JpaRepository<EventHandled, String> {
+	boolean existsByEventId(String eventId);
+
+	List<EventHandled> findEventIdsByEventIdIn(Set<String> eventIds);
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventHandled/EventHandledRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventHandled/EventHandledRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.loopers.infrastructure.eventHandled;
+
+import com.loopers.domain.eventHandled.EventHandled;
+import com.loopers.domain.eventHandled.EventHandledRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class EventHandledRepositoryImpl implements EventHandledRepository {
+
+	private final EventHandledJpaRepository eventHandledJpaRepository;
+
+	@Override
+	public boolean existsByEventId(String eventId) {
+		return eventHandledJpaRepository.existsByEventId(eventId);
+	}
+
+	@Override
+	public EventHandled save(EventHandled eventHandled) {
+		return eventHandledJpaRepository.save(eventHandled);
+	}
+
+	@Override
+	public Set<String> findEventIds(Set<String> eventIds) {
+		return eventHandledJpaRepository.findEventIdsByEventIdIn(eventIds).stream()
+				.map(EventHandled::getEventId)
+				.collect(Collectors.toSet());
+	}
+
+	@Override
+	public List<EventHandled> saveAll(List<EventHandled> eventHandleds) {
+		return eventHandledJpaRepository.saveAll(eventHandleds);
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -3,5 +3,9 @@ package com.loopers.infrastructure.metrics;
 import com.loopers.domain.metrics.ProductMetrics;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
+	Optional<ProductMetrics> findByProductIdAndDate(Long productId, LocalDate date);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
+	private final ProductMetricsJpaRepository productMetricsJpaRepository;
+
+	@Override
+	public List<ProductMetrics> saveAll(List<ProductMetrics> productMetricsList) {
+		return productMetricsJpaRepository.saveAll(productMetricsList);
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -5,7 +5,9 @@ import com.loopers.domain.metrics.ProductMetricsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -13,7 +15,12 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
 	private final ProductMetricsJpaRepository productMetricsJpaRepository;
 
 	@Override
-	public List<ProductMetrics> saveAll(List<ProductMetrics> productMetricsList) {
-		return productMetricsJpaRepository.saveAll(productMetricsList);
+	public ProductMetrics save(ProductMetrics productMetrics) {
+		return productMetricsJpaRepository.save(productMetrics);
+	}
+
+	@Override
+	public Optional<ProductMetrics> findByProductIdAndDate(Long productId, LocalDate date) {
+		return productMetricsJpaRepository.findByProductIdAndDate(productId, date);
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/DemoKafkaConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/DemoKafkaConsumer.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.consumer;
+
+import com.loopers.confg.kafka.KafkaConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DemoKafkaConsumer {
+    @KafkaListener(
+        topics = {"${demo-kafka.test.topic-name}"},
+        containerFactory = KafkaConfig.BATCH_LISTENER
+    )
+    public void demoListener(
+        List<ConsumerRecord<Object,Object>> messages,
+        Acknowledgment acknowledgment
+    ){
+        System.out.println(messages);
+        acknowledgment.acknowledge();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/auditlog/AuditLogConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/auditlog/AuditLogConsumer.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -24,15 +25,17 @@ public class AuditLogConsumer {
 			groupId = "${kafka.group.audit-topic-group-id}",
 			containerFactory = KafkaConfig.STRING_BATCH_LISTENER
 	)
-	public void consume(List<ConsumerRecord<String, String>> records) {
+	public void consume(List<ConsumerRecord<String, String>> records, Acknowledgment ack) {
 		List<AuditLogCommand> commands = records.stream()
 				.map(record -> {
 					String payload = record.value();
 					String eventType = new String(record.headers().lastHeader("eventType").value(), StandardCharsets.UTF_8);
-					return AuditLogCommand.of(eventType, payload);
+					String eventId = new String(record.headers().lastHeader("eventId").value(), StandardCharsets.UTF_8);
+					return AuditLogCommand.of(eventId, eventType, payload);
 				})
 				.toList();
 
 		auditLogService.saveAuditLog(commands);
+		ack.acknowledge();
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/auditlog/AuditLogConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/auditlog/AuditLogConsumer.java
@@ -1,0 +1,38 @@
+package com.loopers.interfaces.consumer.auditlog;
+
+import com.loopers.application.auditlog.AuditLogCommand;
+import com.loopers.application.auditlog.AuditLogService;
+import com.loopers.confg.kafka.KafkaConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuditLogConsumer {
+
+	private final AuditLogService auditLogService;
+
+	@KafkaListener(
+			topics = "${kafka.topic.audit-topic-name}",
+			groupId = "${kafka.group.audit-topic-group-id}",
+			containerFactory = KafkaConfig.STRING_BATCH_LISTENER
+	)
+	public void consume(List<ConsumerRecord<String, String>> records) {
+		List<AuditLogCommand> commands = records.stream()
+				.map(record -> {
+					String payload = record.value();
+					String eventType = new String(record.headers().lastHeader("eventType").value(), StandardCharsets.UTF_8);
+					return AuditLogCommand.of(eventType, payload);
+				})
+				.toList();
+
+		auditLogService.saveAuditLog(commands);
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsConsumer.java
@@ -5,6 +5,7 @@ import com.loopers.application.metrics.ProductMetricsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -19,9 +20,10 @@ public class ProductMetricsConsumer {
 			groupId = "${kafka.group.product-metrics-group-id}",
 			concurrency = "3"
 	)
-	public void consume(ProductMetricsDto productMetricsDto) {
+	public void consume(ProductMetricsDto productMetricsDto, Acknowledgment ack) {
 		ProductMetricsCommand command = productMetricsDto.toCommand();
 		productMetricsService.handleMetrics(command);
+		ack.acknowledge();
 	}
 
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsConsumer.java
@@ -2,14 +2,10 @@ package com.loopers.interfaces.consumer.metrics;
 
 import com.loopers.application.metrics.ProductMetricsCommand;
 import com.loopers.application.metrics.ProductMetricsService;
-import com.loopers.confg.kafka.KafkaConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Slf4j
 @Component
@@ -21,14 +17,11 @@ public class ProductMetricsConsumer {
 	@KafkaListener(
 			topics = "${kafka.topic.product-metrics}",
 			groupId = "${kafka.group.product-metrics-group-id}",
-			containerFactory = KafkaConfig.BATCH_LISTENER
+			concurrency = "3"
 	)
-	public void consume(List<ProductMetricsDto> records) {
-		List<ProductMetricsCommand> commands = records.stream()
-				.map(ProductMetricsDto::toCommand)
-				.toList();
-
-		productMetricsService.handleMetrics(commands);
+	public void consume(ProductMetricsDto productMetricsDto) {
+		ProductMetricsCommand command = productMetricsDto.toCommand();
+		productMetricsService.handleMetrics(command);
 	}
 
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsConsumer.java
@@ -1,0 +1,34 @@
+package com.loopers.interfaces.consumer.metrics;
+
+import com.loopers.application.metrics.ProductMetricsCommand;
+import com.loopers.application.metrics.ProductMetricsService;
+import com.loopers.confg.kafka.KafkaConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductMetricsConsumer {
+
+	private final ProductMetricsService productMetricsService;
+
+	@KafkaListener(
+			topics = "${kafka.topic.product-metrics}",
+			groupId = "${kafka.group.product-metrics-group-id}",
+			containerFactory = KafkaConfig.BATCH_LISTENER
+	)
+	public void consume(List<ProductMetricsDto> records) {
+		List<ProductMetricsCommand> commands = records.stream()
+				.map(ProductMetricsDto::toCommand)
+				.toList();
+
+		productMetricsService.handleMetrics(commands);
+	}
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsDto.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsDto.java
@@ -3,11 +3,12 @@ package com.loopers.interfaces.consumer.metrics;
 import com.loopers.application.metrics.ProductMetricsCommand;
 
 public record ProductMetricsDto(
+		String eventId,
 		Long ProductId,
 		String eventType,
 		int delta
 ) {
 	public ProductMetricsCommand toCommand() {
-		return new ProductMetricsCommand(ProductId, eventType, delta);
+		return new ProductMetricsCommand(eventId, ProductId, eventType, delta);
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsDto.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsDto.java
@@ -1,0 +1,13 @@
+package com.loopers.interfaces.consumer.metrics;
+
+import com.loopers.application.metrics.ProductMetricsCommand;
+
+public record ProductMetricsDto(
+		Long ProductId,
+		String eventType,
+		int delta
+) {
+	public ProductMetricsCommand toCommand() {
+		return new ProductMetricsCommand(ProductId, eventType, delta);
+	}
+}

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -1,0 +1,58 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - kafka.yml
+      - logging.yml
+      - monitoring.yml
+
+demo-kafka:
+  test:
+    topic-name: demo.internal.topic-v1
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 server:
+  port: 8084
   shutdown: graceful
   tomcat:
     threads:
@@ -10,11 +11,12 @@ server:
     keep-alive-timeout: 60s # 60s
   max-http-request-header-size: 8KB
 
+
 spring:
   main:
     web-application-type: servlet
   application:
-    name: commerce-api
+    name: commerce-streamer
   profiles:
     active: local
   config:
@@ -23,11 +25,18 @@ spring:
       - redis.yml
       - kafka.yml
       - logging.yml
-      - monitoring.yml
 
 demo-kafka:
   test:
     topic-name: demo.internal.topic-v1
+
+kafka:
+  topic:
+    audit-topic-name: audit.topic-v1
+    product-metrics: product.metrics-v1
+  group:
+    audit-topic-group-id: audit.topic-group
+    product-metrics-group-id: product.metrics-group
 
 ---
 spring:

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -54,15 +54,57 @@ services:
         "--latency-monitor-threshold", "100",
       ]
     healthcheck:
-      test: ["CMD", "redis-cli", "-p", "6380", "PING"]
+      test: ["CMD", "redis-cli", "-p", "6379", "PING"]
       interval: 5s
       timeout: 2s
       retries: 10
+
+  kafka:
+    image: bitnami/kafka:3.5.1
+    container_name: kafka
+    ports:
+      - "9092:9092" # 카프카 브로커 PORT
+      - "19092:19092" # 호스트 리스너
+    environment:
+      - KAFKA_CFG_NODE_ID=1 # 브로커 고유 ID
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller # KRaft 모드여서, broker / controller 역할 모두 부여
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,PLAINTEXT_HOST://:19092,CONTROLLER://:9093
+      # 브로커 클라이언트 (PLAINTEXT), 브로커 호스트 (PLAINTEXT) 내부 컨트롤러 (CONTROLLER)
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:19092
+      # 외부 클라이언트 접속 호스트 (localhost:9092), 브로커 접속 호스트 (localhost:19092)
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      # 각 리스너별 보안 프로토콜 설정
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER # 컨트롤러 담당 리스너 지정
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093 # 컨트롤러 후보 노드 정의 (단일 브로커라 자기 자신만 있음)
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1 # consumer offset 복제 갯수 (현재는 1 - 로컬용이라서)
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 # transaction log 토픽 복제 갯수 (현재는 1 - 로컬용이라서)
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1 # In-Sync-Replica 최소 수 (현재는 1 - 로컬용이라서)
+    volumes:
+      - kafka-data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD", "bash", "-c", "kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "9090:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local  # kafka-ui 에서 보이는 클러스터명
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092 # kafka-ui 가 연겷할 브로커 주소
 
 volumes:
   mysql-8-data:
   redis_master_data:
   redis_readonly_data:
+  kafka-data:
 
 networks:
   default:

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -95,7 +95,7 @@ services:
       kafka:
         condition: service_healthy
     ports:
-      - "9090:8080"
+      - "9091:8080"
     environment:
       KAFKA_CLUSTERS_0_NAME: local  # kafka-ui 에서 보이는 클러스터명
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092 # kafka-ui 가 연겷할 브로커 주소

--- a/modules/kafka/build.gradle.kts
+++ b/modules/kafka/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api("org.springframework.kafka:spring-kafka")
+
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+    testImplementation("org.testcontainers:kafka")
+
+    testFixturesImplementation("org.testcontainers:kafka")
+}

--- a/modules/kafka/src/main/java/com/loopers/confg/kafka/KafkaConfig.java
+++ b/modules/kafka/src/main/java/com/loopers/confg/kafka/KafkaConfig.java
@@ -1,0 +1,75 @@
+package com.loopers.confg.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
+import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+@EnableConfigurationProperties(KafkaProperties.class)
+public class KafkaConfig {
+    public static final String BATCH_LISTENER = "BATCH_LISTENER_DEFAULT";
+
+    public static final int MAX_POLLING_SIZE = 3000; // read 3000 msg
+    public static final int FETCH_MIN_BYTES = (1024 * 1024); // 1mb
+    public static final int FETCH_MAX_WAIT_MS = 5 * 1000; // broker waiting time = 5s
+    public static final int SESSION_TIMEOUT_MS = 60 * 1000; // session timeout = 1m
+    public static final int HEARTBEAT_INTERVAL_MS = 20 * 1000; // heartbeat interval = 20s ( 1/3 of session_timeout )
+    public static final int MAX_POLL_INTERVAL_MS = 2 * 60 * 1000; // max poll interval = 2m
+
+    @Bean
+    public ProducerFactory<Object, Object> producerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties());
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public ConsumerFactory<Object, Object> consumerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties());
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<Object, Object> kafkaTemplate(ProducerFactory<Object, Object> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+
+    @Bean
+    public ByteArrayJsonMessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
+        return new ByteArrayJsonMessageConverter(objectMapper);
+    }
+
+    @Bean(name = BATCH_LISTENER)
+    public ConcurrentKafkaListenerContainerFactory<Object, Object> defaultBatchListenerContainerFactory(
+            KafkaProperties kafkaProperties,
+            ByteArrayJsonMessageConverter converter
+    ) {
+        Map<String, Object> consumerConfig = new HashMap<>(kafkaProperties.buildConsumerProperties());
+        consumerConfig.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, MAX_POLLING_SIZE);
+        consumerConfig.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, FETCH_MIN_BYTES);
+        consumerConfig.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, FETCH_MAX_WAIT_MS);
+        consumerConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, SESSION_TIMEOUT_MS);
+        consumerConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, HEARTBEAT_INTERVAL_MS);
+        consumerConfig.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL_MS);
+
+        ConcurrentKafkaListenerContainerFactory<Object, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerConfig));
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL); // 수동 커밋
+        factory.setBatchMessageConverter(new BatchMessagingMessageConverter(converter));
+        factory.setConcurrency(3);
+        factory.setBatchListener(true);
+        return factory;
+    }
+}

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -1,0 +1,44 @@
+spring:
+  kafka:
+    bootstrap-servers: ${BOOTSTRAP_SERVERS}
+    client-id: ${spring.application.name}
+    properties:
+        spring.json.add.type.headers: false # json serialize off
+        request.timeout.ms: 20000
+        retry.backoff.ms: 500
+        auto:
+          create.topics.enable: false
+          register.schemas: false
+          offset.reset: latest
+        use.latest.version: true
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      retries: 3
+    consumer:
+      group-id: loopers-default-consumer
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-serializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      properties:
+        enable-auto-commit: false
+    listener:
+      ack-mode: manual
+
+---
+spring.config.activate.on-profile: local, test
+
+spring:
+  kafka:
+    bootstrap-servers: localhost:19092
+    admin:
+      properties:
+        bootstrap.servers: kafka:9092
+
+---
+spring.config.activate.on-profile: dev
+
+---
+spring.config.activate.on-profile: qa
+
+---
+spring.config.activate.on-profile: prd

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -15,6 +15,8 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       retries: 3
+      acks: all
+      enable-idempotence: true
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,9 +2,11 @@ rootProject.name = "tacoShop"
 
 include(
     ":apps:commerce-api",
+    ":apps:commerce-streamer",
     ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",
+    ":modules:kafka",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",


### PR DESCRIPTION
## 📌 Summary
- 모든 이벤트에 대한 감사 로그 저장 👉 [67088ea](https://github.com/tastingcode/tacoShop/pull/22/commits/67088ea955e95b833d4b1333b5eff507b1fb092f)
- 일별로 좋아요 수, 판매량, 조회 수 변화량 집계 👉 [0908933](https://github.com/tastingcode/tacoShop/pull/22/commits/0908933efd5c065a2e998af31184f11d57efa44a) 👉 [fc2a659](https://github.com/tastingcode/tacoShop/pull/22/commits/fc2a659bb6c3e66b52551ccb4f67b651b2bd7515)
- 캐시 무효화 - 좋아요 변경 시 상품 목록 좋아요 정렬 기준 캐시 삭제 👉[b10747a](https://github.com/tastingcode/tacoShop/pull/22/commits/b10747ad010d0d6e33e2637732e720849d3ed97d)
## 💬 Review Points
- ApplicationEvent를 카프카 메시지 발행 도움닫기(?)로 사용해도 괜찮을까요?
  - 현재 카프카 메시지 발행이 필요한 경우 ApplicationEvent 발행 -> 이벤트 리스너에서 이를 감지 후 필요 시 카프카 메시지를 발행
  - 예로 상품 상세 조회의 경우 집계 처리를 위해 카프카 메시지 발행만 필요한 상황인데, 1차적으로 ProductViewdEvent 를 발행하고 리스너에서 이를 감지한 뒤에 카프카 메시지를 발행하고 있습니다.
  - 이러한 패턴으로 가야 하나의 서비스는 하나의 서비스를 완료했다는 이벤트만 발행하고, 이를 리스너에서 감지하여 해당 이벤트에 대한 처리가 용이할 것이라고 생각하였습니다.

- 컨슈머에서 집계 처리를 할 때에도 동시성 이슈를 고려해야 하나요?
  - 집계 처리 시 상품 아이디와, 일자로 해당 row를 조회한 뒤에 업데이트 하고 있습니다.
  - 집계도 중요한 비즈니스로 간주하고,  동시성 이슈를 고려하여 정확한 수치를 기록해야 하나요?

- 이직 준비에 있어 카프카는 어느 정도의 수준 까지 공부하는 게 좋을까요?
  - 이번에 카프카 입문 강의를 수강하고 과제를 진행하며 카프카를 접할 수 있었습니다.
  - 지금까지 배웠던 내용들과 카프카를 포함하여 좀 더 효율적으로 학습하여 전략적으로 이직을 준비하고 싶습니다.
  - 인덱스, 트랜잭션, 레디스 등 많이 중요하다고 찝어주신 부분이 있는데, 카프카 역시 우선 순위와 비중을 어떻게 두고 준비하는 게 좋을까요?

## ✅ Checklist
### 🎾 Producer

- [x]  도메인(애플리케이션) 이벤트 설계
- [x]  Producer 앱에서 도메인 이벤트 발행 (catalog-events, order-events, 등)
- [ ]  **PartitionKey** 기반의 이벤트 순서 보장
- [x]  메세지 발행이 실패했을 경우에 대해 고민해보기

### ⚾ Consumer

- [x]  Consumer 앱에서 3종 처리 (Audit Log / Cache Evict / Metrics 집계)
- [x]  `event_handled` 테이블을 통한 멱등 처리 구현
- [ ]  재고 소진 시 상품 캐시 삭제
- [ ]  중복 메세지 재전송 테스트 → 최종 결과가 한 번만 반영되는지 확인

