### PR TITLE
[volume-21] Round9: 랭킹

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/metrics/ProductMetricsEventHandler.java
@@ -27,7 +27,8 @@ public class ProductMetricsEventHandler {
 
 	public void handleLikeMetrics(ProductLikeEvent event){
 		int delta = event.likeEventType().equals(LikeEventType.LIKE) ? 1 : -1;
-		ProductMetricsCommand productMetricsCommand = ProductMetricsCommand.of(event.eventId(), event.productId(), event.getEventType(), delta);
+		String eventType = event.likeEventType().equals(LikeEventType.LIKE) ? "ProductLikeEvent" : "ProductUnlikeEvent";
+		ProductMetricsCommand productMetricsCommand = ProductMetricsCommand.of(event.eventId(), event.productId(), eventType, delta);
 
 		sendMetrics(productMetricsCommand);
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
@@ -3,7 +3,7 @@ package com.loopers.application.product;
 import com.loopers.domain.product.ProductDetail;
 
 public record ProductInfo(Long productId, String productName, int price, int stock, int likeCount, Long brandId,
-						  String brandName, String brandDescription) {
+						  String brandName, String brandDescription, Long rank) {
 	public static ProductInfo from(ProductDetail productDetail) {
 		return new ProductInfo(
 				productDetail.productId(),
@@ -11,8 +11,22 @@ public record ProductInfo(Long productId, String productName, int price, int sto
 				productDetail.price(),
 				productDetail.stock(),
 				productDetail.likeCount(),
-				productDetail.brandId() != null ? productDetail.brandId() : null,
-				productDetail.brandName() != null ? productDetail.brandName() : null,
-				productDetail.brandDescription() != null ? productDetail.brandDescription() : null);
+				productDetail.brandId(),
+				productDetail.brandName(),
+				productDetail.brandDescription(),
+				null
+		);
+	}
+
+	public ProductInfo withRank(Long rank) {
+		return new ProductInfo(productId,
+				productName,
+				price,
+				stock,
+				likeCount,
+				brandId,
+				brandName,
+				brandDescription,
+				rank);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/event/ProductLikeEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/event/ProductLikeEventHandler.java
@@ -23,13 +23,9 @@ public class ProductLikeEventHandler {
 	private final ProductRepository productRepository;
 	private final ProductCacheRepository productCacheRepository;
 
-	@Retryable(
-			retryFor = ObjectOptimisticLockingFailureException.class,
-			maxAttempts = 5,
-			backoff = @Backoff(delay = 100))
 	@Transactional
 	public void updateLikeCount(ProductLikeEvent event) {
-		Product product = productDomainService.getProduct(event.productId());
+		Product product = productDomainService.getProductForUpdate(event.productId());
 
 		if (event.likeEventType() == LikeEventType.LIKE)
 			product.increaseLikeCount();

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingAssembler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingAssembler.java
@@ -1,0 +1,30 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.product.Product;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class RankingAssembler {
+
+	public List<RankingInfo> getRankingProducts(List<Long> productIds,
+												Map<Long, Product> productsMap,
+												long start) {
+
+		long currentRank = start + 1;
+		List<RankingInfo> rankingInfoList = new ArrayList<>();
+
+		for (Long productId : productIds) {
+			Product product = productsMap.get(productId);
+			RankingInfo rankingInfo = RankingInfo.of(product, currentRank);
+			rankingInfoList.add(rankingInfo);
+			currentRank++;
+		}
+
+		return rankingInfoList;
+	}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
@@ -2,12 +2,14 @@ package com.loopers.application.ranking;
 
 public record RankingCommand(
 		String date,
+		int page,
+		int size,
 		long start,
 		long end
 ) {
 	public static RankingCommand from(String date, int page, int size) {
 		long start = (long) size * (page - 1);
 		long end = start + size - 1;
-		return new RankingCommand(date, start, end);
+		return new RankingCommand(date, page, size, start, end);
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
@@ -1,0 +1,13 @@
+package com.loopers.application.ranking;
+
+public record RankingCommand(
+		String date,
+		long start,
+		long end
+) {
+	public static RankingCommand from(String date, int page, int size) {
+		long start = (long) size * (page - 1);
+		long end = start + size - 1;
+		return new RankingCommand(date, start, end);
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingInfo.java
@@ -1,0 +1,25 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.product.Product;
+
+public record RankingInfo(
+		Long productId,
+		String productName,
+		int price,
+		int stock,
+		Long brandId,
+		int likeCount,
+		long rank
+) {
+	public static RankingInfo of(Product p, long rank) {
+		return new RankingInfo(
+				p.getId(),
+				p.getName(),
+				p.getPrice(),
+				p.getStock(),
+				p.getBrandId(),
+				p.getLikeCount(),
+				rank
+		);
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingListInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingListInfo.java
@@ -1,0 +1,22 @@
+package com.loopers.application.ranking;
+
+import java.util.List;
+
+public record RankingListInfo(
+		List<RankingInfo> rankingInfos,
+		int page,
+		int size,
+		long totalCount,
+		int totalPage
+) {
+	public static RankingListInfo from(List<RankingInfo> rankingInfos,
+									 int page,
+									 int size,
+									 long totalCount) {
+		return new RankingListInfo(rankingInfos,
+				page,
+				size,
+				totalCount,
+				(int) Math.ceil((double) totalCount / size));
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
@@ -1,0 +1,39 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductDomainService;
+import com.loopers.domain.ranking.RankingDomainService;
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+	private final RankingRepository rankingRepository;
+	private final RankingDomainService rankingDomainService;
+	private final ProductDomainService productDomainService;
+	private final RankingAssembler rankingAssembler;
+
+
+	public List<RankingInfo> getRankingList(RankingCommand command) {
+		// 랭킹 키 조회
+		String dailyKey = rankingDomainService.getDailyKey(command.date());
+
+		// 랭킹 목록(상품 아이디) 조회
+		List<Long> productIds = rankingRepository.getRankingProductIds(dailyKey, command.start(), command.end());
+
+		// 상품 목록 Map 조회
+		Map<Long, Product> productsMap = productDomainService.getProductsMap(productIds);
+
+		// 랭킹 상품 조회
+		List<RankingInfo> rankingInfos = rankingAssembler.getRankingProducts(productIds, productsMap, command.start());
+
+		return rankingInfos;
+	}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
@@ -20,7 +20,7 @@ public class RankingService {
 	private final RankingAssembler rankingAssembler;
 
 
-	public List<RankingInfo> getRankingList(RankingCommand command) {
+	public RankingListInfo getRankingList(RankingCommand command) {
 		// 랭킹 키 조회
 		String dailyKey = rankingDomainService.getDailyKey(command.date());
 
@@ -33,7 +33,11 @@ public class RankingService {
 		// 랭킹 상품 조회
 		List<RankingInfo> rankingInfos = rankingAssembler.getRankingProducts(productIds, productsMap, command.start());
 
-		return rankingInfos;
+		// 토탈 카운트 조회
+		Long totalCount = rankingDomainService.getTotalCountBy(dailyKey);
+
+		// 랭킹 목록 정보
+		return RankingListInfo.from(rankingInfos, command.page(), command.size(), totalCount);
 	}
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/dataplatform/DataPlatformDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/dataplatform/DataPlatformDto.java
@@ -1,16 +1,16 @@
 package com.loopers.domain.dataplatform;
 
 public class DataPlatformDto {
-	public record Result(
+	public record Result<T>(
 			DataResultStatus status,
-			Long userId,
+			T userId,
 			String message
 	) {
-		public static Result success(Long userId, String message) {
+		public static <T>Result<T> success(T userId, String message) {
 			return new Result(DataResultStatus.SUCCESS, userId, message);
 		}
 
-		public static Result fail(Long userId, String message) {
+		public static <T>Result<T> fail(T userId, String message) {
 			return new Result(DataResultStatus.FAILURE, userId, message);
 		}
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderDomainService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderDomainService.java
@@ -2,11 +2,12 @@ package com.loopers.domain.order;
 
 
 import com.loopers.domain.product.Product;
-import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductDomainService;
 import com.loopers.domain.user.UserEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,8 +18,8 @@ import java.util.List;
 public class OrderDomainService {
 
 	private final OrderRepository orderRepository;
-	private final ProductRepository productRepository;
 	private final OrderProductRepository orderProductRepository;
+	private final ProductDomainService productDomainService;
 
 	@Transactional
 	public Order createOrder(UserEntity user, List<OrderProduct> orderProducts, int orderPrice, int discountAmount, Long couponId) {
@@ -29,8 +30,7 @@ public class OrderDomainService {
 	@Transactional
 	public void deductStocks(List<OrderProduct> orderProducts) {
 		orderProducts.forEach(orderProduct -> {
-			Product product = productRepository.findByIdForUpdate(orderProduct.getProductId())
-					.orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다. 상품 ID: "));
+			Product product = productDomainService.getProductForUpdate(orderProduct.getProductId());
 			product.deductStock(orderProduct.getQuantity());
 		});
 	}
@@ -38,8 +38,7 @@ public class OrderDomainService {
 	@Transactional
 	public void restoreStocks(List<OrderProduct> orderProducts) {
 		orderProducts.forEach(orderProduct -> {
-			Product product = productRepository.findByIdForUpdate(orderProduct.getProductId())
-					.orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다. 상품 ID: "));
+			Product product = productDomainService.getProductForUpdate(orderProduct.getProductId());
 			product.restoreStock(orderProduct.getQuantity());
 		});
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -27,8 +27,6 @@ public class Product extends BaseEntity {
 	@Column(name = "ref_brand_id", nullable = false)
 	private Long brandId;
 	private int likeCount;
-	@Version
-	private Long version;
 
 	@Builder
 	public Product (String name, int price, int stock, Long brandId, int likeCount) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductDetail.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductDetail.java
@@ -12,7 +12,8 @@ public record ProductDetail(Long productId, String productName, int price, int s
 				product.getLikeCount(),
 				brand != null ? brand.getId() : null,
 				brand != null ? brand.getName() : null,
-				brand != null ? brand.getDescription() : null);
+				brand != null ? brand.getDescription() : null
+				);
 	}
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductDomainService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductDomainService.java
@@ -25,6 +25,11 @@ public class ProductDomainService {
 				.orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
 	}
 
+	public Product getProductForUpdate(Long productId){
+		return productRepository.findByIdForUpdate(productId)
+				.orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다. 상품 ID: "));
+	}
+
 	public Page<ProductDetail> getProductsByQuery(ProductQuery productQuery) {
 		return productRepository.findProductsWithBrand(productQuery);
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductDomainService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductDomainService.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.product;
 
 import com.loopers.application.product.ProductQuery;
+import com.loopers.domain.BaseEntity;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.order.OrderProduct;
 import com.loopers.support.error.CoreException;
@@ -10,6 +11,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
@@ -24,6 +28,7 @@ public class ProductDomainService {
 	public Page<ProductDetail> getProductsByQuery(ProductQuery productQuery) {
 		return productRepository.findProductsWithBrand(productQuery);
 	}
+
 	public List<Product> getProductsByOrderProducts(List<OrderProduct> orderProducts) {
 		List<Long> productIds = orderProducts.stream()
 				.map(OrderProduct::getProductId)
@@ -33,6 +38,13 @@ public class ProductDomainService {
 
 	public ProductDetail assembleProductDetail(Product product, Brand brand) {
 		return ProductDetail.of(product, brand);
+	}
+
+	public Map<Long, Product> getProductsMap(List<Long> productIds) {
+		List<Product> products = productRepository.findAllByIdIn(productIds);
+
+		return products.stream()
+				.collect(Collectors.toMap(Product::getId, Function.identity()));
 	}
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -19,4 +19,6 @@ public interface ProductRepository {
 
 	List<Product> saveAll(List<Product> products);
 
+	List<Product> findAllByIdIn(List<Long> productIds);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingDomainService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingDomainService.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.ranking;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class RankingDomainService {
+
+	private final RankingRepository rankingRepository;
+
+	private static final String KEY_PREFIX = "ranking:all:";
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+	public String getDailyKey(String date){
+		String key = date;
+		if (date == null)
+			key = LocalDate.now().format(DATE_FORMATTER);
+
+		return KEY_PREFIX + key;
+	}
+
+	// 일단 금일 랭킹 기준 조회 TODO 주간, 월간 기준 등
+	public Long getRankBy(Long productId){
+		String rankingKey = KEY_PREFIX + LocalDate.now().format(DATE_FORMATTER);
+		return rankingRepository.getRank(rankingKey, productId);
+	}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingDomainService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingDomainService.java
@@ -29,4 +29,8 @@ public class RankingDomainService {
 		return rankingRepository.getRank(rankingKey, productId);
 	}
 
+	public Long getTotalCountBy(String rankingKey){
+		return rankingRepository.findTotalCount(rankingKey);
+	}
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -7,4 +7,6 @@ public interface RankingRepository {
 	List<Long> getRankingProductIds(String rankingKey, long start, long end);
 
 	Long getRank(String rankingKey, Long productId);
+
+	Long findTotalCount(String rankingKey);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.ranking;
+
+import java.util.List;
+
+public interface RankingRepository {
+
+	List<Long> getRankingProductIds(String rankingKey, long start, long end);
+
+	Long getRank(String rankingKey, Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/DataPlatformAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/DataPlatformAdapter.java
@@ -36,10 +36,10 @@ public class DataPlatformAdapter implements DataPlatformPort {
 					event.orderId(),
 					event.paymentId());
 
-			return DataPlatformDto.Result.success(Long.valueOf(event.userId()), "주문 결과 정보 전송 성공");
+			return DataPlatformDto.Result.success(event.userId(), "주문 결과 정보 전송 성공");
 		} catch (Exception e) {
 			log.error("[데이터 플랫폼] 주문 결과 정보 전송 실패: {}", e.getMessage());
-			return DataPlatformDto.Result.fail(Long.valueOf(event.userId()), "주문 결과 정보 전송 실패");
+			return DataPlatformDto.Result.fail(event.userId(), "주문 결과 정보 전송 실패");
 		}
 	}
 
@@ -51,10 +51,10 @@ public class DataPlatformAdapter implements DataPlatformPort {
 					event.orderId(),
 					event.paymentId());
 
-			return DataPlatformDto.Result.success(Long.valueOf(event.userId()), "결제-주문 결과 정보 전송 성공");
+			return DataPlatformDto.Result.success(event.userId(), "결제-주문 결과 정보 전송 성공");
 		} catch (Exception e) {
 			log.error("[데이터 플랫폼] 결제-주문 결과 정보 전송 실패: {}", e.getMessage());
-			return DataPlatformDto.Result.fail(Long.valueOf(event.userId()), "결제-주문 결과 정보 전송 실패");
+			return DataPlatformDto.Result.fail(event.userId(), "결제-주문 결과 정보 전송 실패");
 		}
 	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductJpaRepository  extends JpaRepository<Product, Long> {
@@ -13,4 +15,6 @@ public interface ProductJpaRepository  extends JpaRepository<Product, Long> {
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT p FROM Product p WHERE p.id = :id")
 	Optional<Product> findByIdForUpdate(Long id);
+
+	List<Product> findAllByIdIn(Collection<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -94,4 +94,9 @@ public class ProductRepositoryImpl implements ProductRepository {
 		return productJpaRepository.saveAll(products);
 	}
 
+	@Override
+	public List<Product> findAllByIdIn(List<Long> productIds) {
+		return productJpaRepository.findAllByIdIn(productIds);
+	}
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -25,4 +25,9 @@ public class RankingRepositoryImpl implements RankingRepository {
 		return rank != null ? rank + 1 : null;
 	}
 
+	@Override
+	public Long findTotalCount(String rankingKey) {
+		return redisTemplate.opsForZSet().zCard(rankingKey);
+	}
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RankingRepositoryImpl implements RankingRepository {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Override
+	public List<Long> getRankingProductIds(String rankingKey, long start, long end) {
+		return redisTemplate.opsForZSet().reverseRange(rankingKey, start, end).stream()
+				.map(Long::valueOf)
+				.toList();
+	}
+
+	@Override
+	public Long getRank(String rankingKey, Long productId) {
+		Long rank = redisTemplate.opsForZSet().reverseRank(rankingKey, productId.toString());
+		return rank != null ? rank + 1 : null;
+	}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
@@ -1,0 +1,18 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+
+@Tag(name = "Like V1 API", description = "Like API 입니다.")
+public interface LikeV1ApiSpec {
+
+	@Operation(summary = "상품 좋아요 등록")
+	ApiResponse<LikeV1Dto.LikeResponse> like(@RequestHeader("X-USER-ID") String userId, LikeV1Dto.LikeRequest request);
+
+	@Operation(summary = "상품 좋아요 취소")
+	ApiResponse<LikeV1Dto.LikeResponse> unlike(@RequestHeader("X-USER-ID") String userId, LikeV1Dto.LikeRequest request);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.application.like.LikeInfo;
+import com.loopers.application.like.LikeService;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/likes")
+public class LikeV1Controller implements LikeV1ApiSpec {
+    private final LikeService likeService;
+
+    @PostMapping
+    @Override
+    public ApiResponse<LikeV1Dto.LikeResponse> like(@RequestHeader("X-USER-ID") String userId, @RequestBody LikeV1Dto.LikeRequest request) {
+		LikeInfo likeInfo = likeService.like(userId, request.productId());
+		LikeV1Dto.LikeResponse response = LikeV1Dto.LikeResponse.from(likeInfo);
+		return ApiResponse.success(response);
+    }
+
+    @DeleteMapping
+    @Override
+    public ApiResponse<LikeV1Dto.LikeResponse> unlike(@RequestHeader("X-USER-ID") String userId, @RequestBody LikeV1Dto.LikeRequest request) {
+		LikeInfo likeInfo = likeService.unlike(userId, request.productId());
+		LikeV1Dto.LikeResponse response = LikeV1Dto.LikeResponse.from(likeInfo);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.like;
+
+
+import com.loopers.application.like.LikeInfo;
+
+public class LikeV1Dto {
+	public record LikeRequest(
+			Long productId
+	) {
+	}
+	public record LikeResponse(
+			Long userId,
+			Long productId,
+			boolean liked
+	) {
+		public static LikeResponse from(LikeInfo likeInfo){
+			return new LikeResponse(likeInfo.userId(), likeInfo.productId(), likeInfo.liked());
+		}
+	}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiController.java
@@ -5,10 +5,7 @@ import com.loopers.application.order.OrderFacade;
 import com.loopers.application.order.OrderInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +14,7 @@ public class OrderV1ApiController implements OrderV1ApiSpec {
 
 	private final OrderFacade orderFacade;
 
+	@PostMapping
 	@Override
 	public ApiResponse<OrderV1Dto.OrderResponse> createOrder(@RequestHeader("X-USER-ID") String userId,
 											   @RequestBody OrderV1Dto.OrderRequest orderRequest) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -22,7 +22,8 @@ public class ProductV1Dto {
 			String productName,
 			int price,
 			int stock,
-			int likeCount
+			int likeCount,
+			Long rank
 	){
 		public static ProductResponse from(ProductInfo productInfo) {
 			return new ProductResponse(productInfo.brandId(),
@@ -31,7 +32,8 @@ public class ProductV1Dto {
 					productInfo.productName(),
 					productInfo.price(),
 					productInfo.stock(),
-					productInfo.likeCount());
+					productInfo.likeCount(),
+					productInfo.rank());
 		}
 	}
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.ranking;
 
 import com.loopers.application.ranking.RankingCommand;
-import com.loopers.application.ranking.RankingInfo;
+import com.loopers.application.ranking.RankingListInfo;
 import com.loopers.application.ranking.RankingService;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +24,14 @@ public class RankingController implements RankingV1ApiSpec {
 
     @GetMapping("")
     @Override
-    public ApiResponse<List<RankingV1Dto.RankingResponse>> getRankingList(
+    public ApiResponse<RankingV1Dto.RankingListResponse> getRankingList(
             @RequestParam (required = false) String date,
             @PageableDefault(page = 1, size = 20) Pageable pageable
     ) {
 		RankingCommand rankingCommand = RankingCommand.from(date, pageable.getPageNumber(), pageable.getPageSize());
-		List<RankingInfo> rankingInfos = rankingService.getRankingList(rankingCommand);
-		List<RankingV1Dto.RankingResponse> responses = RankingV1Dto.RankingResponse.from(rankingInfos);
-        return ApiResponse.success(responses);
+		RankingListInfo rankingListInfo = rankingService.getRankingList(rankingCommand);
+		RankingV1Dto.RankingListResponse response = RankingV1Dto.RankingListResponse.from(rankingListInfo);
+		return ApiResponse.success(response);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -1,0 +1,37 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingCommand;
+import com.loopers.application.ranking.RankingInfo;
+import com.loopers.application.ranking.RankingService;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/rankings")
+public class RankingController implements RankingV1ApiSpec {
+
+	private final RankingService rankingService;
+
+    @GetMapping("")
+    @Override
+    public ApiResponse<List<RankingV1Dto.RankingResponse>> getRankingList(
+            @RequestParam (required = false) String date,
+            @PageableDefault(page = 1, size = 20) Pageable pageable
+    ) {
+		RankingCommand rankingCommand = RankingCommand.from(date, pageable.getPageNumber(), pageable.getPageSize());
+		List<RankingInfo> rankingInfos = rankingService.getRankingList(rankingCommand);
+		List<RankingV1Dto.RankingResponse> responses = RankingV1Dto.RankingResponse.from(rankingInfos);
+        return ApiResponse.success(responses);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+
+@Tag(name = "Ranking V1 API", description = "랭킹 API 입니다.")
+public interface RankingV1ApiSpec {
+
+	@Operation(summary = "랭킹 목록 조회")
+	ApiResponse<List<RankingV1Dto.RankingResponse>> getRankingList(@RequestParam String date,
+																   @PageableDefault(page = 1, size = 20) Pageable pageable);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface RankingV1ApiSpec {
 
 	@Operation(summary = "랭킹 목록 조회")
-	ApiResponse<List<RankingV1Dto.RankingResponse>> getRankingList(@RequestParam String date,
-																   @PageableDefault(page = 1, size = 20) Pageable pageable);
+	ApiResponse<RankingV1Dto.RankingListResponse> getRankingList(@RequestParam String date,
+																	   @PageableDefault(page = 1, size = 20) Pageable pageable);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -1,35 +1,25 @@
 package com.loopers.interfaces.api.ranking;
 
 import com.loopers.application.ranking.RankingInfo;
+import com.loopers.application.ranking.RankingListInfo;
 
 import java.util.List;
 
 public class RankingV1Dto {
 
-    public record RankingResponse(
-            Long productId,
-            String productName,
-            int price,
-			int stock,
-			Long brandId,
-            int likeCount,
-            long rank
+    public record RankingListResponse(
+			List<RankingInfo> rankingInfos,
+			int page,
+			int size,
+			long totalCount,
+			int totalPage
     ) {
-
-        public static List<RankingResponse> from(List<RankingInfo> infos) {
-            return infos.stream()
-                    .map(info -> new RankingResponse(
-                            info.productId(),
-                            info.productName(),
-                            info.price(),
-							info.stock(),
-							info.brandId(),
-                            info.likeCount(),
-                            info.rank()
-                    ))
-                    .toList();
-        }
-
+		public static RankingListResponse from(RankingListInfo rankingListInfo) {
+			return new RankingListResponse(rankingListInfo.rankingInfos(),
+					rankingListInfo.page(),
+					rankingListInfo.size(),
+					rankingListInfo.totalCount(),
+					rankingListInfo.totalPage());
+		}
     }
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -1,0 +1,35 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingInfo;
+
+import java.util.List;
+
+public class RankingV1Dto {
+
+    public record RankingResponse(
+            Long productId,
+            String productName,
+            int price,
+			int stock,
+			Long brandId,
+            int likeCount,
+            long rank
+    ) {
+
+        public static List<RankingResponse> from(List<RankingInfo> infos) {
+            return infos.stream()
+                    .map(info -> new RankingResponse(
+                            info.productId(),
+                            info.productName(),
+                            info.price(),
+							info.stock(),
+							info.brandId(),
+                            info.likeCount(),
+                            info.rank()
+                    ))
+                    .toList();
+        }
+
+    }
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogService.java
@@ -27,7 +27,7 @@ public class AuditLogService {
 				.collect(Collectors.toSet());
 
 		// 이벤트 핸들 ID 조회
-		Set<String> handledEventIds = eventHandledDomainService.getEventIds(eventIdSet);
+		Set<String> handledEventIds = eventHandledDomainService.getEventSet(eventIdSet);
 
 		// 이미 처리 된 이벤트 제외한 감사로그 생성
 		List<AuditLog> auditLogs = commands.stream()

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/auditlog/AuditLogService.java
@@ -3,7 +3,7 @@ package com.loopers.application.auditlog;
 import com.loopers.domain.auditlog.AuditLog;
 import com.loopers.domain.auditlog.AuditLogRepository;
 import com.loopers.domain.eventHandled.EventHandled;
-import com.loopers.domain.eventHandled.EventHandledRepository;
+import com.loopers.domain.eventHandled.EventHandledDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,15 +16,18 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AuditLogService {
 
-	private final EventHandledRepository eventHandledRepository;
+	private final EventHandledDomainService eventHandledDomainService;
 	private final AuditLogRepository auditLogRepository;
 
 	@Transactional
 	public void saveAuditLog(List<AuditLogCommand> commands) {
-		// 이벤트 핸들 ID 조회
-		Set<String> handledEventIds = eventHandledRepository.findEventIds(commands.stream()
+		// eventIds
+		Set<String> eventIdSet = commands.stream()
 				.map(AuditLogCommand::eventId)
-				.collect(Collectors.toSet()));
+				.collect(Collectors.toSet());
+
+		// 이벤트 핸들 ID 조회
+		Set<String> handledEventIds = eventHandledDomainService.getEventIds(eventIdSet);
 
 		// 이미 처리 된 이벤트 제외한 감사로그 생성
 		List<AuditLog> auditLogs = commands.stream()
@@ -41,6 +44,6 @@ public class AuditLogService {
 		auditLogRepository.saveAll(auditLogs);
 
 		// 이벤트 핸들 저장
-		eventHandledRepository.saveAll(eventHandleds);
+		eventHandledDomainService.saveEventHandledList(eventHandleds);
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/eventHandled/EventHandledService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/eventHandled/EventHandledService.java
@@ -1,0 +1,34 @@
+package com.loopers.application.eventHandled;
+
+import com.loopers.application.metrics.ProductMetricsCommand;
+import com.loopers.domain.eventHandled.EventHandled;
+import com.loopers.domain.eventHandled.EventHandledDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EventHandledService {
+
+	private final EventHandledDomainService eventHandledDomainService;
+
+	public Set<String> getAlreadyHandledEventIdSet(List<ProductMetricsCommand> commands){
+		Set<String> eventIdSet = commands.stream()
+				.map(ProductMetricsCommand::eventId)
+				.collect(Collectors.toSet());
+
+		return eventHandledDomainService.getEventSet(eventIdSet);
+	}
+
+	public List<EventHandled> extractUnhandledEventHandledList(List<ProductMetricsCommand> commands, Set<String> eventIdSet) {
+		return commands.stream()
+				.filter(command -> !eventIdSet.contains(command.eventId()))
+				.map(command -> EventHandled.of(command.eventId()))
+				.toList();
+	}
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsFacade.java
@@ -1,75 +1,36 @@
 package com.loopers.application.metrics;
 
-import com.loopers.application.auditlog.AuditLogCommand;
-import com.loopers.application.ranking.RankingService;
+import com.loopers.application.eventHandled.EventHandledService;
 import com.loopers.domain.eventHandled.EventHandled;
 import com.loopers.domain.eventHandled.EventHandledDomainService;
-import com.loopers.domain.metrics.MetricType;
-import com.loopers.domain.metrics.ProductMetrics;
-import com.loopers.domain.metrics.ProductMetricsDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class MetricsFacade {
 
-	private final ProductMetricsDomainService productMetricsDomainService;
+	private final EventHandledService eventHandledService;
+	private final ProductMetricsService productMetricsService;
 	private final EventHandledDomainService eventHandledDomainService;
-	private final RankingService rankingService;
 
 	@Transactional
-	public void handleMetrics(List<ProductMetricsCommand> commands) {
-		// eventIds
-		Set<String> eventIdSet = commands.stream()
-				.map(ProductMetricsCommand::eventId)
-				.collect(Collectors.toSet());
-
+	public void processMetrics(List<ProductMetricsCommand> commands) {
 		// 이벤트 핸들 ID 조회
-		Set<String> handledEventIds = eventHandledDomainService.getEventIds(eventIdSet);
+		Set<String> eventIdSet = eventHandledService.getAlreadyHandledEventIdSet(commands);
 
-		// 이미 처리 된 이벤트 제외
-		List<ProductMetricsCommand> unhandledCommands = commands.stream()
-				.filter(command -> !handledEventIds.contains(command.eventId()))
-				.toList();
+		// 처리되지 않은 이벤트 핸들 목록 추출
+		List<EventHandled> eventHandledList = eventHandledService.extractUnhandledEventHandledList(commands, eventIdSet);
 
-		List<EventHandled> eventHandleds = unhandledCommands.stream()
-				.map(command -> EventHandled.of(command.eventId()))
-				.toList();
-
-		Map<Long, List<ProductMetricsCommand>> groupedMetricsCommands = commands.stream()
-				.filter(command -> !handledEventIds.contains(command.eventId()))
-				.collect(Collectors.groupingBy(ProductMetricsCommand::ProductId));
-
-		for (Map.Entry<Long, List<ProductMetricsCommand>> entry : groupedMetricsCommands.entrySet()) {
-			Long productId = entry.getKey();
-			List<ProductMetricsCommand> productMetricsCommands = entry.getValue();
-
-			// ProductMetrics 조회
-			ProductMetrics productMetrics = productMetricsDomainService.getProductMetrics(productId);
-
-			for (ProductMetricsCommand command : productMetricsCommands) {
-				// ProductMetrics 업데이트
-				productMetricsDomainService.updateMetricsDeltas(productMetrics, MetricType.from(command.eventType()), command.delta());
-			}
-
-			// ProductMetrics 저장
-			ProductMetrics saveMetrics = productMetricsDomainService.saveMetrics(productMetrics);
-
-			// 랭킹 처리
-			rankingService.updateRankingByMetrics(saveMetrics);
-		}
-
+		// 집계 및 랭킹 업데이트
+		productMetricsService.updateMetricsAndRanking(commands, eventIdSet);
 
 		// 이벤트 핸들 저장
-		eventHandledDomainService.saveEventHandledList(eventHandleds);
-
+		eventHandledDomainService.saveEventHandledList(eventHandledList);
 	}
 
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/MetricsFacade.java
@@ -1,0 +1,75 @@
+package com.loopers.application.metrics;
+
+import com.loopers.application.auditlog.AuditLogCommand;
+import com.loopers.application.ranking.RankingService;
+import com.loopers.domain.eventHandled.EventHandled;
+import com.loopers.domain.eventHandled.EventHandledDomainService;
+import com.loopers.domain.metrics.MetricType;
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class MetricsFacade {
+
+	private final ProductMetricsDomainService productMetricsDomainService;
+	private final EventHandledDomainService eventHandledDomainService;
+	private final RankingService rankingService;
+
+	@Transactional
+	public void handleMetrics(List<ProductMetricsCommand> commands) {
+		// eventIds
+		Set<String> eventIdSet = commands.stream()
+				.map(ProductMetricsCommand::eventId)
+				.collect(Collectors.toSet());
+
+		// 이벤트 핸들 ID 조회
+		Set<String> handledEventIds = eventHandledDomainService.getEventIds(eventIdSet);
+
+		// 이미 처리 된 이벤트 제외
+		List<ProductMetricsCommand> unhandledCommands = commands.stream()
+				.filter(command -> !handledEventIds.contains(command.eventId()))
+				.toList();
+
+		List<EventHandled> eventHandleds = unhandledCommands.stream()
+				.map(command -> EventHandled.of(command.eventId()))
+				.toList();
+
+		Map<Long, List<ProductMetricsCommand>> groupedMetricsCommands = commands.stream()
+				.filter(command -> !handledEventIds.contains(command.eventId()))
+				.collect(Collectors.groupingBy(ProductMetricsCommand::ProductId));
+
+		for (Map.Entry<Long, List<ProductMetricsCommand>> entry : groupedMetricsCommands.entrySet()) {
+			Long productId = entry.getKey();
+			List<ProductMetricsCommand> productMetricsCommands = entry.getValue();
+
+			// ProductMetrics 조회
+			ProductMetrics productMetrics = productMetricsDomainService.getProductMetrics(productId);
+
+			for (ProductMetricsCommand command : productMetricsCommands) {
+				// ProductMetrics 업데이트
+				productMetricsDomainService.updateMetricsDeltas(productMetrics, MetricType.from(command.eventType()), command.delta());
+			}
+
+			// ProductMetrics 저장
+			ProductMetrics saveMetrics = productMetricsDomainService.saveMetrics(productMetrics);
+
+			// 랭킹 처리
+			rankingService.updateRankingByMetrics(saveMetrics);
+		}
+
+
+		// 이벤트 핸들 저장
+		eventHandledDomainService.saveEventHandledList(eventHandleds);
+
+	}
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
@@ -39,4 +39,5 @@ public class ProductMetricsService {
 		// 이벤트 핸들 처리
 		eventHandledDomainService.saveEventHandled(command.eventId());
 	}
+
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
@@ -1,5 +1,6 @@
 package com.loopers.application.metrics;
 
+import com.loopers.application.ranking.RankingService;
 import com.loopers.domain.eventHandled.EventHandledDomainService;
 import com.loopers.domain.metrics.MetricType;
 import com.loopers.domain.metrics.ProductMetrics;
@@ -14,7 +15,9 @@ public class ProductMetricsService {
 
 	private final EventHandledDomainService eventHandledDomainService;
 	private final ProductMetricsDomainService productMetricsDomainService;
+	private final RankingService rankingService;
 
+	// TODO Refactor: MetricsFacade -> 1.isHandled() 2.saveMetrics() 3.updateRanking() 4.saveEventHandled()
 	@Transactional
 	public void handleMetrics(ProductMetricsCommand command) {
 		// 이벤트 중복 처리 확인
@@ -29,6 +32,9 @@ public class ProductMetricsService {
 
 		// ProductMetrics 저장
 		productMetricsDomainService.saveMetrics(productMetrics);
+
+		// 랭킹 처리
+		rankingService.updateRanking(command.ProductId(), MetricType.from(command.eventType()));
 
 		// 이벤트 핸들 처리
 		eventHandledDomainService.saveEventHandled(command.eventId());

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
@@ -1,43 +1,54 @@
 package com.loopers.application.metrics;
 
 import com.loopers.application.ranking.RankingService;
-import com.loopers.domain.eventHandled.EventHandledDomainService;
 import com.loopers.domain.metrics.MetricType;
 import com.loopers.domain.metrics.ProductMetrics;
 import com.loopers.domain.metrics.ProductMetricsDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class ProductMetricsService {
 
-	private final EventHandledDomainService eventHandledDomainService;
 	private final ProductMetricsDomainService productMetricsDomainService;
 	private final RankingService rankingService;
 
-	// TODO Refactor: MetricsFacade -> 1.isHandled() 2.saveMetrics() 3.updateRanking() 4.saveEventHandled()
-	@Transactional
-	public void handleMetrics(ProductMetricsCommand command) {
-		// 이벤트 중복 처리 확인
-		if (eventHandledDomainService.isHandled(command.eventId()))
-			return;
+	public void updateMetricsAndRanking(List<ProductMetricsCommand> commands, Set<String> eventIdSet) {
+		// 처리되지 않은 집계 커맨드 목록 맵 추출
+		Map<Long, List<ProductMetricsCommand>> commandMap = extractUnhandledCommandMap(commands, eventIdSet);
 
-		// ProductMetrics 조회
-		ProductMetrics productMetrics = productMetricsDomainService.getProductMetrics(command.ProductId());
+		for (Map.Entry<Long, List<ProductMetricsCommand>> entry : commandMap.entrySet()) {
+			// ProductMetrics 조회
+			Long productId = entry.getKey();
+			ProductMetrics productMetrics = productMetricsDomainService.getProductMetrics(productId);
 
-		// ProductMetrics 업데이트
-		productMetricsDomainService.updateMetricsDeltas(productMetrics, MetricType.from(command.eventType()), command.delta());
 
-		// ProductMetrics 저장
-		productMetricsDomainService.saveMetrics(productMetrics);
+			// ProductMetrics 업데이트
+			List<ProductMetricsCommand> productMetricsCommands = entry.getValue();
+			for (ProductMetricsCommand command : productMetricsCommands) {
+				productMetricsDomainService.updateMetricsDeltas(productMetrics, MetricType.from(command.eventType()), command.delta());
+			}
 
-		// 랭킹 처리
-		rankingService.updateRanking(command.ProductId(), MetricType.from(command.eventType()));
+			// ProductMetrics 저장
+			ProductMetrics saveMetrics = productMetricsDomainService.saveMetrics(productMetrics);
 
-		// 이벤트 핸들 처리
-		eventHandledDomainService.saveEventHandled(command.eventId());
+			// 랭킹 처리
+			rankingService.updateRankingByMetrics(saveMetrics);
+		}
+	}
+
+	public Map<Long, List<ProductMetricsCommand>> extractUnhandledCommandMap(List<ProductMetricsCommand> commands, Set<String> eventIdSet) {
+		Map<Long, List<ProductMetricsCommand>> metricsCommandMap = commands.stream()
+				.filter(command -> !eventIdSet.contains(command.eventId()))
+				.collect(Collectors.groupingBy(ProductMetricsCommand::ProductId));
+
+		return metricsCommandMap;
 	}
 
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingService.java
@@ -1,0 +1,34 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.metrics.MetricType;
+import com.loopers.domain.ranking.RankingDomainService;
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+	private final RankingRepository rankingRepository;
+	private final RankingDomainService rankingDomainService;
+
+	private static final Map<MetricType, Double> SCORE_MAP = Map.of(
+			MetricType.PRODUCT_SALES, 1.0,
+			MetricType.PRODUCT_LIKE, 0.1,
+			MetricType.PRODUCT_VIEWED, 0.052
+	);
+
+	public void updateRanking(Long productId, MetricType metricType) {
+		// 일간 랭킹 키
+		String dailyKey = rankingDomainService.getDailyKey();
+		Double score = SCORE_MAP.get(metricType);
+
+		rankingRepository.updateScore(dailyKey, productId, score);
+
+		rankingRepository.setCacheExpiration(dailyKey, Duration.ofDays(2));
+	}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingService.java
@@ -1,6 +1,8 @@
 package com.loopers.application.ranking;
 
+import com.loopers.application.metrics.ProductMetricsCommand;
 import com.loopers.domain.metrics.MetricType;
+import com.loopers.domain.metrics.ProductMetrics;
 import com.loopers.domain.ranking.RankingDomainService;
 import com.loopers.domain.ranking.RankingRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +21,13 @@ public class RankingService {
 	private static final Map<MetricType, Double> SCORE_MAP = Map.of(
 			MetricType.PRODUCT_SALES, 1.0,
 			MetricType.PRODUCT_LIKE, 0.1,
-			MetricType.PRODUCT_VIEWED, 0.052
+			MetricType.PRODUCT_UNLIKE, -0.1,
+			MetricType.PRODUCT_VIEWED, 0.05
 	);
+
+	private final Double LIKE_WEIGHT = 0.1;
+	private final Double SALES_WEIGHT = 1.0;
+	private final Double VIEWED_WEIGHT = 0.05;
 
 	public void updateRanking(Long productId, MetricType metricType) {
 		// 일간 랭킹 키
@@ -29,6 +36,13 @@ public class RankingService {
 
 		rankingRepository.updateScore(dailyKey, productId, score);
 
+		rankingRepository.setCacheExpiration(dailyKey, Duration.ofDays(2));
+	}
+
+	public void updateRankingByMetrics(ProductMetrics productMetrics) {
+		String dailyKey = rankingDomainService.getDailyKey();
+		double score = productMetrics.getLikesDelta() * LIKE_WEIGHT + productMetrics.getSalesDelta() * SALES_WEIGHT + productMetrics.getViewsDelta() * VIEWED_WEIGHT;
+		rankingRepository.updateScore(dailyKey, productMetrics.getProductId(), score);
 		rankingRepository.setCacheExpiration(dailyKey, Duration.ofDays(2));
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledDomainService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledDomainService.java
@@ -16,8 +16,8 @@ public class EventHandledDomainService {
 		return eventHandledRepository.existsByEventId(eventId);
 	}
 
-	public Set<String> getEventIds(Set<String> eventIdSet){
-		return eventHandledRepository.findEventIds(eventIdSet);
+	public Set<String> getEventSet(Set<String> eventIdSet){
+		return eventHandledRepository.findEventIdSet(eventIdSet);
 	}
 
 	public List<EventHandled> saveEventHandledList(List<EventHandled> eventHandledList) {

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledDomainService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledDomainService.java
@@ -4,6 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Set;
+
 @Component
 @RequiredArgsConstructor
 public class EventHandledDomainService {
@@ -11,6 +14,14 @@ public class EventHandledDomainService {
 
 	public boolean isHandled(String eventId) {
 		return eventHandledRepository.existsByEventId(eventId);
+	}
+
+	public Set<String> getEventIds(Set<String> eventIdSet){
+		return eventHandledRepository.findEventIds(eventIdSet);
+	}
+
+	public List<EventHandled> saveEventHandledList(List<EventHandled> eventHandledList) {
+		return eventHandledRepository.saveAll(eventHandledList);
 	}
 
 	@Transactional

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventHandled/EventHandledRepository.java
@@ -5,7 +5,10 @@ import java.util.Set;
 
 public interface EventHandledRepository {
 	boolean existsByEventId(String eventId);
+
 	EventHandled save(EventHandled eventHandled);
-	Set<String> findEventIds(Set<String> eventIds);
+
+	Set<String> findEventIdSet(Set<String> eventIds);
+
 	List<EventHandled> saveAll(List<EventHandled> eventHandleds);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricType.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricType.java
@@ -2,6 +2,7 @@ package com.loopers.domain.metrics;
 
 public enum MetricType {
 	PRODUCT_LIKE("ProductLikeEvent"),
+	PRODUCT_UNLIKE("ProductUnlikeEvent"),
 	PRODUCT_VIEWED("ProductViewedEvent"),
 	PRODUCT_SALES("PaymentOrderSuccessEvent");
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsDomainService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsDomainService.java
@@ -19,14 +19,14 @@ public class ProductMetricsDomainService {
 
 	public void updateMetricsDeltas(ProductMetrics productMetrics, MetricType metricType, int delta) {
 		switch (metricType) {
-			case PRODUCT_LIKE -> productMetrics.adjustLikesDelta(delta);
+			case PRODUCT_LIKE, PRODUCT_UNLIKE -> productMetrics.adjustLikesDelta(delta);
 			case PRODUCT_SALES -> productMetrics.increaseSalesDelta(delta);
 			case PRODUCT_VIEWED -> productMetrics.increaseViewsDelta(delta);
 		}
 	}
 
 	@Transactional
-	public void saveMetrics(ProductMetrics productMetrics){
-		productMetricsRepository.save(productMetrics);
+	public ProductMetrics saveMetrics(ProductMetrics productMetrics){
+		return productMetricsRepository.save(productMetrics);
 	}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingDomainService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingDomainService.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.ranking;
+
+import org.apache.kafka.common.protocol.types.Field;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class RankingDomainService {
+
+	private static final String KEY_PREFIX = "ranking:all:";
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+	public String getDailyKey(){
+		String today = LocalDate.now().format(DATE_FORMATTER);
+		return KEY_PREFIX + today;
+	}
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.ranking;
+
+
+import java.time.Duration;
+
+public interface RankingRepository {
+
+	void updateScore(String rankingKey, Long productId, double score);
+
+	void setCacheExpiration(String rankingKey, Duration ttl);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventHandled/EventHandledRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventHandled/EventHandledRepositoryImpl.java
@@ -26,7 +26,7 @@ public class EventHandledRepositoryImpl implements EventHandledRepository {
 	}
 
 	@Override
-	public Set<String> findEventIds(Set<String> eventIds) {
+	public Set<String> findEventIdSet(Set<String> eventIds) {
 		return eventHandledJpaRepository.findEventIdsByEventIdIn(eventIds).stream()
 				.map(EventHandled::getEventId)
 				.collect(Collectors.toSet());

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RankingRepositoryImpl implements RankingRepository {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Override
+	public void updateScore(String rankingKey, Long productId, double score) {
+		redisTemplate.opsForZSet().incrementScore(rankingKey, productId.toString(), score);
+	}
+
+	@Override
+	public void setCacheExpiration(String rankingKey, Duration ttl) {
+		redisTemplate.expire(rankingKey, ttl);
+	}
+
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/metrics/ProductMetricsConsumer.java
@@ -2,7 +2,6 @@ package com.loopers.interfaces.consumer.metrics;
 
 import com.loopers.application.metrics.MetricsFacade;
 import com.loopers.application.metrics.ProductMetricsCommand;
-import com.loopers.application.metrics.ProductMetricsService;
 import com.loopers.confg.kafka.KafkaConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,19 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProductMetricsConsumer {
 
-	private final ProductMetricsService productMetricsService;
 	private final MetricsFacade metricsFacade;
-
-	/*@KafkaListener(
-			topics = "${kafka.topic.product-metrics}",
-			groupId = "${kafka.group.product-metrics-group-id}",
-			concurrency = "3"
-	)
-	public void consume(ProductMetricsDto productMetricsDto, Acknowledgment ack) {
-		ProductMetricsCommand command = productMetricsDto.toCommand();
-		productMetricsService.handleMetrics(command);
-		ack.acknowledge();
-	}*/
 
 	@KafkaListener(
 			topics = "${kafka.topic.product-metrics}",
@@ -41,7 +28,7 @@ public class ProductMetricsConsumer {
 				.map(ProductMetricsDto::toCommand)
 				.toList();
 
-		metricsFacade.handleMetrics(commands);
+		metricsFacade.processMetrics(commands);
 		ack.acknowledge();
 	}
 

--- a/docker/sql/dummy-data.sql
+++ b/docker/sql/dummy-data.sql
@@ -2,16 +2,19 @@
 SET
 @NUM_BRANDS   = 100;
 SET
-@NUM_USERS    = 50000;
+# @NUM_USERS    = 50000;
+@NUM_USERS    = 500;
 SET
-@NUM_PRODUCTS = 1000000;
+# @NUM_PRODUCTS = 1000000;
+@NUM_PRODUCTS = 10000;
 SET
-@MAX_LIKES_PER_PRODUCT = 50000;
+# @MAX_LIKES_PER_PRODUCT = 50000;
+@MAX_LIKES_PER_PRODUCT = 500;
 
 SET SESSION cte_max_recursion_depth = 2000000;
 
 -- ===== brands =====
-INSERT INTO brand (name, description, created_at, updated_at)
+INSERT INTO loopers.brand (name, description, created_at, updated_at)
 WITH RECURSIVE cte(n) AS (SELECT 1
                           UNION ALL
                           SELECT n + 1
@@ -32,14 +35,14 @@ SELECT CONCAT('brand', LPAD(n, 3, '0')),
 FROM cte;
 
 -- ===== users (member) =====
-INSERT INTO member (user_id, name, gender, birth, email, created_at, updated_at)
+INSERT INTO loopers.member (user_id, name, gender, birth, email, created_at, updated_at)
 WITH RECURSIVE cte(n) AS (SELECT 1
                           UNION ALL
                           SELECT n + 1
                           FROM cte
                           WHERE n < @NUM_USERS)
 SELECT CONCAT('user', LPAD(n, 6, '0'))                                             AS user_id,
-       CONCAT('User', LPAD(n, 6, '0'))                                             AS name,
+       CONCAT('user', LPAD(n, 6, '0'))                                             AS name,
        CASE WHEN n % 2 = 0 THEN 'M' ELSE 'F' END                                   AS gender,
        DATE_FORMAT(DATE_ADD('1980-01-01', INTERVAL (n MOD 15000) DAY), '%Y-%m-%d') AS birth,
        CONCAT('user', LPAD(n, 6, '0'), '@example.com')                             AS email,
@@ -56,14 +59,14 @@ SELECT CONCAT('user', LPAD(n, 6, '0'))                                          
 FROM cte;
 
 -- ===== products =====
-INSERT INTO product (name, price, stock, ref_brand_id, like_count, created_at, updated_at)
+INSERT INTO loopers.product (name, price, stock, ref_brand_id, like_count, created_at, updated_at)
 WITH RECURSIVE cte(n) AS (SELECT 1
                           UNION ALL
                           SELECT n + 1
                           FROM cte
                           WHERE n < @NUM_PRODUCTS)
 SELECT CONCAT('item', LPAD(n, 7, '0'))                    AS name,
-       (FLOOR(RAND(n * 7) * 50) + 1) * 1000               AS price,      -- 1,000 ~ 50,000 (1천원 단위)
+       10000                                              AS price,
        (FLOOR(RAND(n * 11) * 96) + 5)                     AS stock,      -- 5 ~ 100
        1 + FLOOR(RAND(n) * @NUM_BRANDS)                   AS brand_id,   -- 1..100
        FLOOR(RAND(n * 13) * (@MAX_LIKES_PER_PRODUCT + 1)) AS like_count, -- 0..50,000
@@ -78,3 +81,73 @@ SELECT CONCAT('item', LPAD(n, 7, '0'))                    AS name,
         TIMESTAMPDIFF(SECOND, @created, NOW())) SECOND
         )
 FROM cte;
+
+-- 1. 정액 할인 쿠폰 (1000원 할인)
+INSERT INTO loopers.coupon (
+    discount_fixed_amount,
+    discount_percentage,
+    minimum_order_price,
+    created_at,
+    updated_at,
+    coupon_code,
+    name,
+    status,
+    type
+) VALUES (
+             1000,                     -- 정액 할인 금액
+             0,                        -- 정률 할인은 0
+             1000,                     -- 최소 주문 금액
+             NOW(), NOW(),
+             'FIX1000',
+             '1000원 정액 할인 쿠폰',
+             'ACTIVE',
+             'FIXED_AMOUNT'
+         );
+
+-- 2. 정률 할인 쿠폰 (10% 할인)
+INSERT INTO loopers.coupon (
+    discount_fixed_amount,
+    discount_percentage,
+    minimum_order_price,
+    created_at,
+    updated_at,
+    coupon_code,
+    name,
+    status,
+    type
+) VALUES (
+             0,                        -- 정액 할인 금액
+             10,                       -- 10% 할인
+             1000,                     -- 최소 주문 금액
+             NOW(), NOW(),
+             'PERC10',
+             '10% 정률 할인 쿠폰',
+             'ACTIVE',
+             'PERCENTAGE'
+         );
+
+
+-- 유저 쿠폰 등록
+-- userId = 1 (user000001의 PK라고 가정)
+
+INSERT INTO loopers.user_coupon (
+    used,
+    created_at,
+    updated_at,
+    ref_coupon_id,
+    ref_user_id,
+    version
+) VALUES (
+             b'0', NOW(), NOW(), 1, 1, 0
+         );
+
+INSERT INTO loopers.user_coupon (
+    used,
+    created_at,
+    updated_at,
+    ref_coupon_id,
+    ref_user_id,
+    version
+) VALUES (
+             b'0', NOW(), NOW(), 2, 1, 0
+         );

--- a/http/commerce-api/like-v1.http
+++ b/http/commerce-api/like-v1.http
@@ -1,0 +1,19 @@
+### 좋아요
+POST {{commerce-api}}/api/v1/likes
+X-USER-ID: user000001
+Content-Type: application/json
+
+{
+  "productId": 1
+}
+
+### 좋아요 취소
+DELETE {{commerce-api}}/api/v1/likes
+X-USER-ID: user000001
+Content-Type: application/json
+
+{
+  "productId": 1
+}
+
+

--- a/http/commerce-api/order-v1.http
+++ b/http/commerce-api/order-v1.http
@@ -1,0 +1,25 @@
+### 주문 요청
+POST {{commerce-api}}/api/v1/orders
+X-USER-ID: user000001
+Content-Type: application/json
+
+{
+    "orderProducts": [
+        {
+            "productId": 1,
+            "price": 10000,
+            "quantity": 1
+        },
+      {
+        "productId": 2,
+        "price": 10000,
+        "quantity": 1
+      },
+      {
+        "productId": 3,
+        "price": 10000,
+        "quantity": 1
+      }
+    ],
+    "couponId": 1
+}

--- a/http/commerce-api/payments-v1.http
+++ b/http/commerce-api/payments-v1.http
@@ -1,0 +1,25 @@
+### 결제 요청(포인트)
+POST {{commerce-api}}/api/v1/payments
+X-USER-ID: user000001
+Content-Type: application/json
+
+{
+  "orderId": 1,
+  "paymentType": "POINT",
+  "cardType": "",
+  "cardNo": "",
+  "amount" : 5000
+}
+
+### 결제 요청(카드)
+POST {{commerce-api}}/api/v1/payments
+X-USER-ID: user000001
+Content-Type: application/json
+
+{
+  "orderId": 1,
+  "paymentType": "CREDIT_CARD",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : 5000
+}

--- a/http/commerce-api/point-v1.http
+++ b/http/commerce-api/point-v1.http
@@ -1,0 +1,14 @@
+### 포인트 충전
+POST {{commerce-api}}/api/v1/points/charge
+X-USER-ID: user000001
+Content-Type: application/json
+
+{
+  "amount": 100000000
+}
+
+### 포인트 조회
+GET {{commerce-api}}/api/v1/points
+X-USER-ID: user000001
+
+

--- a/http/commerce-api/product-v1.http
+++ b/http/commerce-api/product-v1.http
@@ -1,0 +1,11 @@
+
+### 상품 목록 조회 (기본)
+GET {{commerce-api}}/api/v1/products
+
+### 상품 목록 조회 (request)
+GET {{commerce-api}}/api/v1/products?brandId=1&productSortType=LIKES_DESC&page=0&size=10
+
+### 상품 상세 조회 (2번 이상 조회 시 랭킹 포함)
+GET {{commerce-api}}/api/v1/products/15
+
+

--- a/http/commerce-api/ranking-v1.http
+++ b/http/commerce-api/ranking-v1.http
@@ -1,2 +1,2 @@
 ### 랭킹 목록 조회
-GET {{commerce-api}}/api/v1/rankings?date=20250912&page=2&size=10
+GET {{commerce-api}}/api/v1/rankings?date=20250912&page=1&size=10

--- a/http/commerce-api/ranking-v1.http
+++ b/http/commerce-api/ranking-v1.http
@@ -1,0 +1,2 @@
+### 랭킹 목록 조회
+GET {{commerce-api}}/api/v1/rankings?date=20250912&page=2&size=10

--- a/http/commerce-api/user-v1.http
+++ b/http/commerce-api/user-v1.http
@@ -1,0 +1,14 @@
+### 회원 가입
+POST {{commerce-api}}/api/v1/users
+Content-Type: application/json
+
+{
+  "userId": "user000001",
+  "name": "user001",
+  "gender": "M",
+  "birth" : "2020-12-12",
+  "email": "user001@email.com"
+}
+
+### 회원 조회
+GET {{commerce-api}}/api/v1/users/user000001

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -1,6 +1,6 @@
 ### 결제 요청
 POST {{pg-simulator}}/api/v1/payments
-X-USER-ID: "moosinsa"
+X-USER-ID: moosinsa
 Content-Type: application/json
 
 {
@@ -8,20 +8,6 @@ Content-Type: application/json
   "cardType": "SAMSUNG",
   "cardNo": "1234-5678-9814-1451",
   "amount" : "5000",
-  "callbackUrl": "http://localhost:8080/api/v1/payments/callback"
-}
-
-### 결제 요청
-POST {{commerce-api}}/api/v1/payments
-X-USER-ID: "testUser"
-Content-Type: application/json
-
-{
-  "orderId": 1,
-  "paymentType": "CREDIT_CARD",
-  "cardType": "SAMSUNG",
-  "cardNo": "1234-5678-9814-1451",
-  "amount" : 5000,
   "callbackUrl": "http://localhost:8080/api/v1/payments/callback"
 }
 


### PR DESCRIPTION
## 📌 Summary
 - 📈 Ranking Consumer - 상품 집계 및 랭킹 처리
   - [ProductMetricsConsumer#consume](https://github.com/tastingcode/tacoShop/pull/23/files#diff-bdbb5370b17a411df1e07e587a4457fee16c9d77d44a87cef117119a3cf3bd09)
   - [MetricsFacade#processMetrics](https://github.com/tastingcode/tacoShop/pull/23/files#diff-bdbb5370b17a411df1e07e587a4457fee16c9d77d44a87cef117119a3cf3bd09)
   - [ProductMetricsService#updateMetricsAndRanking](https://github.com/tastingcode/tacoShop/pull/23/files#diff-6ca8621e0b0d90824f4efefdf5d13bc4e77f5c8fd9488ce7f28e0859d1b4f6df)
   - [RankingService#updateRankingByMetrics](https://github.com/tastingcode/tacoShop/pull/23/files#diff-51836618df6e73ffef97d1413ee2676cada52dd136f9c1d891c6e534d25cd646)
- ⚾ Ranking API - 랭킹 상품 목록 및 상세 처리
  - [RankingService#getRankingList](https://github.com/tastingcode/tacoShop/pull/23/files#diff-6afaf19c35f9653fb9d6920e390bb73f0fc8ef65dbd26fe320e47655069bb123)
  - [RankingAssembler#getRankingProducts](https://github.com/tastingcode/tacoShop/pull/23/files#diff-6afaf19c35f9653fb9d6920e390bb73f0fc8ef65dbd26fe320e47655069bb123)
  - [ProductService#getProductDetail](https://github.com/tastingcode/tacoShop/pull/23/files#diff-6ca8621e0b0d90824f4efefdf5d13bc4e77f5c8fd9488ce7f28e0859d1b4f6df)

## 💬 Review Points

 - 카프카 리스너는 단건으로 사용 할 일이 없나요?
   - 예를 들어 결제 이벤트의 경우 즉시 처리되어야 하므로 단건 처리 리스너를 생각해 보았습니다.
   - 하지만 많은 트래픽이 발생하는 서비스 (ex. 토스 페이먼츠) 역시 배치 리스너를 사용하고 fetch.max.wait.ms를 줄여서 사용할 것 같습니다.
   - 단건 리스너는 빠른 구현 및 정합성을 보장하기에 좀 더 용이한 점 말고는 장점이 없어보이는데, 실무에서는 단건으로 메시지를 처리하는 일이 없나요?

- 하나의 토픽으로 집계 및 랭킹 처리를 진행해도 될까요?
  - [ProductMetricsConsumer#consume](https://github.com/tastingcode/tacoShop/pull/23/files#diff-bdbb5370b17a411df1e07e587a4457fee16c9d77d44a87cef117119a3cf3bd09) [MetricsFacade#processMetrics](https://github.com/tastingcode/tacoShop/pull/23/files#diff-bdbb5370b17a411df1e07e587a4457fee16c9d77d44a87cef117119a3cf3bd09) 에서 집계 및 랭킹 처리를 진행하고 있습니다.
  - 집계 및 랭킹은 같은 성격으로 보아 이를 이벤트 등으로 분리 할 필요를 느끼지 못했습니다.
  - Consumer의 랭킹 처리 서비스 입장에서 서로 다른 랭킹 이벤트 메시지들은 가중치만 다를 뿐, 한 종류의 랭킹 이벤트로 보았습니다.

 - 카프카를 사용하는 컨슈머에서도 동시성 이슈가 발생한다면 그건 휴먼 이슈일까요?
   - 메시지의 순서를 보장하고 이벤트 핸들을 통해 정합성을 보장하기 용이할 것 같습니다.
   - 휴먼 이슈를 제외하고도 동시성 이슈가 발생하는 경우가 있을까요?

## ✅ Checklist

### 📈 Ranking Consumer
- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API
- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)